### PR TITLE
Improve overall media capture ability

### DIFF
--- a/docs/IMAGE_STORAGE_IMPLEMENTATION.md
+++ b/docs/IMAGE_STORAGE_IMPLEMENTATION.md
@@ -1,0 +1,283 @@
+# 📸 Image Storage Feature - Implementation Guide
+
+## 🎯 Overview
+
+Your WhatsApp Stealth Companion bot has been enhanced to store **all images** (and other media) organized by room, expanding beyond just view-once and story media. This implementation provides a comprehensive, configurable, and manageable media storage system.
+
+## 🏗️ Architecture Summary
+
+### **Files Added/Modified:**
+
+#### ✅ **New Handler Files:**
+- `src/handlers/imageHandler.js` - Handles regular image messages
+- `src/handlers/mediaHandler.js` - Comprehensive media handler (images, videos, audio, documents)
+
+#### ✅ **Configuration:**
+- `src/config/imageConfig.js` - Configurable filters and storage options
+
+#### ✅ **Enhanced Services:**
+- `src/services/mediaHandler.js` - Enhanced with new `saveMedia()` and `handleMediaMessage()` functions
+
+#### ✅ **Management Utilities:**
+- `src/utils/mediaManager.js` - Storage analysis and management functions
+- `mediaManager.js` - CLI tool for media management
+
+#### ✅ **Updated Core:**
+- `src/handlers/messageHandler.js` - Integrated media handling into main message flow
+
+## 📂 Directory Structure
+
+Your media will now be organized as follows:
+
+```
+data/
+├── images/           # Regular images organized by room
+│   ├── {roomId}/
+│   │   └── {chatId}_{timestamp}.{ext}
+├── media/            # Other media types organized by room and type
+│   ├── {roomId}/
+│   │   ├── video/
+│   │   ├── audio/
+│   │   ├── voice/
+│   │   └── document/
+├── viewonce/         # View-once images (existing)
+│   └── {roomId}/
+└── stories/          # Story media (existing)
+    └── {senderId}/
+```
+
+## ⚙️ Configuration Options
+
+### **Basic Configuration** (`src/config/imageConfig.js`)
+
+```javascript
+export const IMAGE_STORAGE_CONFIG = {
+	// Enable/disable regular image storage
+	enableRegularImages: true,
+	
+	// File size limits
+	maxFileSize: 50 * 1024 * 1024, // 50MB
+	minFileSize: 1024, // 1KB
+	
+	// Supported formats
+	supportedFormats: ['image/jpeg', 'image/png', 'image/gif', 'image/webp'],
+	
+	// Room/contact filters
+	filters: {
+		skipRooms: [],        // Skip specific rooms
+		onlyRooms: [],        // Only process specific rooms
+		skipSenders: [],      // Skip specific senders
+		skipGroups: false,    // Skip group chats
+		skipPrivateChats: false
+	}
+};
+```
+
+### **Media Type Configuration** (`src/handlers/mediaHandler.js`)
+
+```javascript
+const MEDIA_CONFIG = {
+	image: { enabled: true, maxSize: 50MB },
+	video: { enabled: true, maxSize: 100MB },
+	audio: { enabled: true, maxSize: 25MB },
+	voice: { enabled: true, maxSize: 10MB },
+	document: { enabled: false, maxSize: 20MB } // Disabled by default
+};
+```
+
+## 🔧 Management Commands
+
+Use the included CLI tool to manage your media storage:
+
+### **View Statistics:**
+```bash
+node mediaManager.js stats
+```
+
+### **Analyze Storage:**
+```bash
+node mediaManager.js analyze
+```
+
+### **Clean Up Old Files:**
+```bash
+# Dry run (preview only)
+node mediaManager.js cleanup --days 30
+
+# Actually delete files
+node mediaManager.js cleanup --days 30 --execute
+```
+
+### **Find Duplicates:**
+```bash
+node mediaManager.js duplicates
+```
+
+### **Export Data:**
+```bash
+# Export as JSON
+node mediaManager.js export > media_data.json
+
+# Export as CSV
+node mediaManager.js export --format csv > media_data.csv
+```
+
+## 🎛️ Customization Options
+
+### **Method 1: Disable Specific Media Types**
+
+Edit `src/handlers/mediaHandler.js`:
+
+```javascript
+const MEDIA_CONFIG = {
+	image: { enabled: true, maxSize: 50 * 1024 * 1024 },
+	video: { enabled: false, maxSize: 100 * 1024 * 1024 }, // Disabled
+	audio: { enabled: false, maxSize: 25 * 1024 * 1024 },  // Disabled
+	// ...
+};
+```
+
+### **Method 2: Filter by Room/Contact**
+
+Edit `src/config/imageConfig.js`:
+
+```javascript
+filters: {
+	// Only save from these rooms
+	onlyRooms: ['120363402876634391@g.us', '6289687981303@s.whatsapp.net'],
+	
+	// Skip these specific rooms
+	skipRooms: ['spam_group@g.us'],
+	
+	// Skip all group chats
+	skipGroups: true,
+}
+```
+
+### **Method 3: Size-Based Filtering**
+
+```javascript
+// Only save images smaller than 10MB
+maxFileSize: 10 * 1024 * 1024,
+
+// Don't save tiny images (likely stickers/emojis)
+minFileSize: 50 * 1024, // 50KB
+```
+
+## 📊 Storage Impact
+
+### **Expected Storage Usage:**
+- **Light Usage**: 100-500 MB/month
+- **Moderate Usage**: 1-5 GB/month  
+- **Heavy Usage**: 5-20 GB/month
+
+### **Performance Considerations:**
+- Each image saves ~2-5ms processing time
+- JSON message storage grows linearly
+- File system impact depends on room organization
+
+## 🚀 Advanced Features
+
+### **1. Database Migration (Future Enhancement)**
+
+For heavy usage, consider migrating from JSON to SQLite:
+
+```javascript
+// Future implementation concept
+const db = new SQLiteDatabase('./data/media.db');
+await db.createTable('media_messages', schema);
+```
+
+### **2. Cloud Storage Integration**
+
+Consider uploading to cloud storage for backup:
+
+```javascript
+// Future implementation concept
+import { uploadToS3 } from './cloudStorage.js';
+const cloudUrl = await uploadToS3(mediaBuffer, filename);
+```
+
+### **3. Content Analysis**
+
+Add automatic content detection:
+
+```javascript
+// Future implementation concept
+import { analyzeImage } from './aiAnalysis.js';
+const tags = await analyzeImage(imageBuffer);
+```
+
+## ⚠️ Important Considerations
+
+### **Legal & Privacy:**
+- Ensure compliance with local privacy laws
+- Consider retention policies for stored media
+- Be mindful of copyright content
+
+### **Storage Management:**
+- Monitor disk space regularly
+- Implement automated cleanup policies
+- Consider external storage for long-term retention
+
+### **Performance:**
+- Large volumes may require database migration
+- Consider async processing for heavy loads
+- Monitor memory usage during media processing
+
+## 🔄 Migration from Current Setup
+
+Your existing data remains unchanged:
+- ✅ View-once images: Still in `./data/viewonce/`
+- ✅ Stories: Still in `./data/stories/`  
+- ✅ Message data: Still in `./data/messages.json`
+- ✅ New regular images: Will be saved to `./data/images/` and `./data/media/`
+
+## 🎯 Next Steps
+
+1. **Test the Implementation:**
+   ```bash
+   # Check if bot starts correctly
+   npm start
+   
+   # Monitor logs for media processing
+   tail -f logs/combined.log
+   ```
+
+2. **Configure Filters:**
+   - Edit `src/config/imageConfig.js` based on your needs
+   - Start with conservative settings and adjust
+
+3. **Monitor Storage:**
+   ```bash
+   # Check storage usage
+   node mediaManager.js stats
+   
+   # Monitor directory sizes
+   du -sh data/*/
+   ```
+
+4. **Set Up Cleanup:**
+   - Create a cron job for regular cleanup
+   - Monitor for duplicates and large files
+
+## 🆘 Troubleshooting
+
+### **Bot Not Saving Images:**
+1. Check `enableRegularImages: true` in config
+2. Verify room filters aren't excluding your chats
+3. Check file size limits
+
+### **High Storage Usage:**
+1. Run `node mediaManager.js analyze`
+2. Use cleanup commands to remove old files
+3. Adjust file size limits in config
+
+### **Performance Issues:**
+1. Monitor memory usage during peak times
+2. Consider disabling video/document storage
+3. Implement more aggressive filtering
+
+---
+
+**🎉 Your WhatsApp bot now comprehensively stores all media organized by room! Use the management tools to keep everything organized and efficient.**

--- a/index.js
+++ b/index.js
@@ -13,7 +13,10 @@ async function main() {
 	botLogger.startup("Initializing Stealth Companion WhatsApp Bot", {
 		authType: CLIENT_CONFIG.authType,
 		database: CLIENT_CONFIG.database.type,
-		features: ["autoOnline", "autoPresence"]
+		autoOnline: CLIENT_CONFIG.autoOnline,
+		autoPresence: CLIENT_CONFIG.autoPresence,
+		autoRead: CLIENT_CONFIG.autoRead,
+		autoRejectCall: CLIENT_CONFIG.autoRejectCall
 	});
 
 	// Create WhatsApp client

--- a/mediaManager.js
+++ b/mediaManager.js
@@ -11,7 +11,7 @@ import {
 	cleanupOldMedia, 
 	findDuplicateMedia, 
 	exportMediaData 
-} from '../src/utils/mediaManager.js';
+} from './src/utils/mediaManager.js';
 
 const commands = {
 	stats: 'Show storage statistics',

--- a/mediaManager.js
+++ b/mediaManager.js
@@ -1,0 +1,203 @@
+#!/usr/bin/env node
+
+/**
+ * Media Management CLI Tool
+ * Usage: node mediaManager.js [command] [options]
+ */
+
+import { 
+	getStorageStatistics, 
+	analyzeMediaDirectories, 
+	cleanupOldMedia, 
+	findDuplicateMedia, 
+	exportMediaData 
+} from '../src/utils/mediaManager.js';
+
+const commands = {
+	stats: 'Show storage statistics',
+	analyze: 'Analyze media directories',
+	cleanup: 'Clean up old media files (dry run by default)',
+	duplicates: 'Find duplicate media files',
+	export: 'Export media data to JSON/CSV'
+};
+
+function showHelp() {
+	console.log('🔧 Media Storage Manager');
+	console.log('========================\n');
+	console.log('Available commands:');
+	Object.entries(commands).forEach(([cmd, desc]) => {
+		console.log(`  ${cmd.padEnd(12)} - ${desc}`);
+	});
+	console.log('\nExamples:');
+	console.log('  node mediaManager.js stats');
+	console.log('  node mediaManager.js cleanup --days 30 --execute');
+	console.log('  node mediaManager.js export --format csv > media_export.csv');
+}
+
+function formatBytes(bytes) {
+	if (bytes === 0) return '0 B';
+	const k = 1024;
+	const sizes = ['B', 'KB', 'MB', 'GB'];
+	const i = Math.floor(Math.log(bytes) / Math.log(k));
+	return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
+}
+
+async function runStats() {
+	console.log('📊 Storage Statistics');
+	console.log('====================\n');
+	
+	const stats = await getStorageStatistics();
+	
+	console.log('📈 Overview:');
+	console.log(`  Total Messages: ${stats.overview.totalMessages}`);
+	console.log(`  Messages with Media: ${stats.overview.messagesWithMedia}`);
+	console.log(`  Estimated Size: ${formatBytes(stats.overview.totalEstimatedSize)}\n`);
+	
+	console.log('📂 By Content Type:');
+	Object.entries(stats.byContentType).forEach(([type, data]) => {
+		console.log(`  ${type}: ${data.count} files (${formatBytes(data.totalSize)})`);
+	});
+	
+	console.log('\n🏠 Top Rooms:');
+	const topRooms = Object.entries(stats.byRoom)
+		.sort((a, b) => b[1].count - a[1].count)
+		.slice(0, 10);
+	topRooms.forEach(([room, data]) => {
+		const groupIcon = data.isGroup ? '👥' : '👤';
+		console.log(`  ${groupIcon} ${room}: ${data.count} files`);
+	});
+	
+	console.log('\n👤 Top Senders:');
+	const topSenders = Object.entries(stats.bySender)
+		.sort((a, b) => b[1].count - a[1].count)
+		.slice(0, 10);
+	topSenders.forEach(([sender, data]) => {
+		console.log(`  ${sender}: ${data.count} files`);
+	});
+}
+
+async function runAnalyze() {
+	console.log('🔍 Directory Analysis');
+	console.log('====================\n');
+	
+	const analysis = await analyzeMediaDirectories();
+	
+	console.log('📊 Overview:');
+	console.log(`  Total Size: ${analysis.overview.formattedSize}`);
+	console.log(`  Total Files: ${analysis.overview.totalFiles}\n`);
+	
+	console.log('📁 Directory Breakdown:');
+	Object.entries(analysis.directories).forEach(([dir, info]) => {
+		if (info.error) {
+			console.log(`  ${dir}: Error - ${info.error}`);
+		} else {
+			console.log(`  ${dir}: ${info.fileCount} files (${info.formattedSize})`);
+		}
+	});
+}
+
+async function runCleanup(args) {
+	const days = parseInt(args.find(arg => arg.startsWith('--days='))?.split('=')[1]) || 30;
+	const execute = args.includes('--execute');
+	
+	console.log(`🧹 Media Cleanup ${execute ? '' : '(DRY RUN)'}`);
+	console.log('==========================================\n');
+	
+	const results = await cleanupOldMedia(days, !execute);
+	
+	console.log(`📊 Cleanup Results (older than ${days} days):`);
+	console.log(`  Files Scanned: ${results.scanned}`);
+	console.log(`  Files to Delete: ${results.toDelete}`);
+	console.log(`  Space to Save: ${results.formattedSpaceSaved}`);
+	
+	if (execute) {
+		console.log(`  Files Deleted: ${results.deletedFiles.length}`);
+		console.log(`  Errors: ${results.errors.length}`);
+	} else {
+		console.log('\n⚠️  This was a dry run. Use --execute to actually delete files.');
+	}
+	
+	if (results.errors.length > 0) {
+		console.log('\n❌ Errors:');
+		results.errors.slice(0, 5).forEach(error => {
+			console.log(`  ${error.file || error.directory}: ${error.error}`);
+		});
+	}
+}
+
+async function runDuplicates() {
+	console.log('🔍 Duplicate Analysis');
+	console.log('====================\n');
+	
+	const duplicates = await findDuplicateMedia();
+	
+	console.log(`📊 Results:`);
+	console.log(`  Potential Duplicates: ${duplicates.potentialDuplicates.length} groups`);
+	console.log(`  Wasted Space: ${duplicates.formattedTotalWaste}\n`);
+	
+	if (duplicates.potentialDuplicates.length > 0) {
+		console.log('🔍 Top Duplicate Groups:');
+		duplicates.potentialDuplicates
+			.sort((a, b) => b.wastedSpace - a.wastedSpace)
+			.slice(0, 10)
+			.forEach((group, index) => {
+				console.log(`\n${index + 1}. ${group.key}`);
+				console.log(`   Duplicates: ${group.duplicateCount}`);
+				console.log(`   Wasted Space: ${formatBytes(group.wastedSpace)}`);
+				group.files.slice(0, 3).forEach(file => {
+					console.log(`   📄 ${file.path}`);
+				});
+				if (group.files.length > 3) {
+					console.log(`   ... and ${group.files.length - 3} more`);
+				}
+			});
+	}
+}
+
+async function runExport(args) {
+	const format = args.find(arg => arg.startsWith('--format='))?.split('=')[1] || 'json';
+	
+	console.log(`📤 Exporting Media Data (${format.toUpperCase()})`);
+	console.log('=======================================\n');
+	
+	const exportData = await exportMediaData(format);
+	console.log(exportData);
+}
+
+async function main() {
+	const [,, command, ...args] = process.argv;
+	
+	if (!command || command === 'help' || command === '--help') {
+		showHelp();
+		return;
+	}
+	
+	try {
+		switch (command) {
+			case 'stats':
+				await runStats();
+				break;
+			case 'analyze':
+				await runAnalyze();
+				break;
+			case 'cleanup':
+				await runCleanup(args);
+				break;
+			case 'duplicates':
+				await runDuplicates();
+				break;
+			case 'export':
+				await runExport(args);
+				break;
+			default:
+				console.error(`❌ Unknown command: ${command}`);
+				showHelp();
+				process.exit(1);
+		}
+	} catch (error) {
+		console.error(`❌ Error: ${error.message}`);
+		process.exit(1);
+	}
+}
+
+main();

--- a/src/config/imageConfig.js
+++ b/src/config/imageConfig.js
@@ -1,0 +1,115 @@
+/**
+ * Image Storage Configuration
+ * Controls which images should be stored and how
+ */
+
+export const IMAGE_STORAGE_CONFIG = {
+	// Enable/disable regular image storage
+	enableRegularImages: true,
+	
+	// File size limits (in bytes)
+	maxFileSize: 50 * 1024 * 1024, // 50MB max
+	minFileSize: 1024, // 1KB min
+	
+	// Supported image formats
+	supportedFormats: [
+		'image/jpeg',
+		'image/jpg', 
+		'image/png',
+		'image/gif',
+		'image/webp'
+	],
+	
+	// Room/contact filters
+	filters: {
+		// Skip these room IDs (empty array = process all)
+		skipRooms: [],
+		
+		// Only process these room IDs (empty array = process all)
+		onlyRooms: [],
+		
+		// Skip these sender IDs (empty array = process all)
+		skipSenders: [],
+		
+		// Skip group messages (true/false)
+		skipGroups: false,
+		
+		// Skip private messages (true/false)
+		skipPrivateChats: false
+	},
+	
+	// Storage organization
+	storage: {
+		// Organize by room (true) or by date (false)
+		organizeByRoom: true,
+		
+		// Create subdirectories by date within room folders
+		addDateSubfolders: false,
+		
+		// Date format for subfolder names (if enabled)
+		dateFormat: 'YYYY-MM-DD'
+	},
+	
+	// Image processing options
+	processing: {
+		// Store original caption as metadata
+		storeCaptions: true,
+		
+		// Store image dimensions
+		storeDimensions: true,
+		
+		// Store sender information
+		storeSenderInfo: true
+	}
+};
+
+/**
+ * Validates if an image should be stored based on configuration
+ * @param {Object} ctx - The message context from Zaileys
+ * @returns {boolean} True if image should be stored
+ */
+export function shouldStoreImage(ctx) {
+	const config = IMAGE_STORAGE_CONFIG;
+	
+	// Check if regular image storage is enabled
+	if (!config.enableRegularImages) {
+		return false;
+	}
+	
+	// Check file size limits
+	if (ctx.media?.fileLength) {
+		if (ctx.media.fileLength > config.maxFileSize || ctx.media.fileLength < config.minFileSize) {
+			return false;
+		}
+	}
+	
+	// Check supported formats
+	if (ctx.media?.mimetype && !config.supportedFormats.includes(ctx.media.mimetype)) {
+		return false;
+	}
+	
+	// Check room filters
+	if (config.filters.skipRooms.length > 0 && config.filters.skipRooms.includes(ctx.roomId)) {
+		return false;
+	}
+	
+	if (config.filters.onlyRooms.length > 0 && !config.filters.onlyRooms.includes(ctx.roomId)) {
+		return false;
+	}
+	
+	// Check sender filters
+	if (config.filters.skipSenders.length > 0 && config.filters.skipSenders.includes(ctx.senderId)) {
+		return false;
+	}
+	
+	// Check group/private chat filters
+	if (ctx.isGroup && config.filters.skipGroups) {
+		return false;
+	}
+	
+	if (!ctx.isGroup && config.filters.skipPrivateChats) {
+		return false;
+	}
+	
+	return true;
+}

--- a/src/config/imageConfig.js
+++ b/src/config/imageConfig.js
@@ -41,13 +41,7 @@ export const IMAGE_STORAGE_CONFIG = {
 	// Storage organization
 	storage: {
 		// Organize by room (true) or by date (false)
-		organizeByRoom: true,
-		
-		// Create subdirectories by date within room folders
-		addDateSubfolders: false,
-		
-		// Date format for subfolder names (if enabled)
-		dateFormat: 'YYYY-MM-DD'
+		organizeByRoom: true
 	},
 	
 	// Image processing options

--- a/src/handlers/imageHandler.js
+++ b/src/handlers/imageHandler.js
@@ -1,0 +1,163 @@
+import { botLogger } from "../../logger.js";
+import { loadMessages, saveMessages } from "../services/messageStorage.js";
+import { handleImageMessage, getMediaFileExtension } from "../services/mediaHandler.js";
+import { shouldStoreImage } from "../config/imageConfig.js";
+
+/**
+ * Detects if a message contains regular image content (not view-once or story)
+ * @param {Object} ctx - The message context from Zaileys
+ * @returns {boolean} True if regular image content is detected, false otherwise
+ */
+export function detectRegularImageContent(ctx) {
+	try {
+		// Check if it's an image message with media
+		const isImage = ctx.chatType === 'image' && ctx.media;
+		
+		// Exclude view-once images (they're handled separately)
+		const isNotViewOnce = !ctx.isViewOnce && !ctx.media?.viewOnce;
+		
+		// Exclude stories (they're handled separately)
+		const isNotStory = !ctx.isStory;
+		
+		// Exclude forwarded view-once content
+		const isNotViewOnceForward = ctx.chatType !== 'viewOnce';
+		
+		// Check configuration filters
+		const passesFilters = shouldStoreImage(ctx);
+		
+		const shouldProcess = isImage && isNotViewOnce && isNotStory && isNotViewOnceForward && passesFilters;
+		
+		botLogger.debug("Regular image detection", {
+			chatId: ctx.chatId,
+			roomId: ctx.roomId,
+			chatType: ctx.chatType,
+			isImage,
+			isNotViewOnce,
+			isNotStory,
+			passesFilters,
+			shouldProcess
+		});
+		
+		return shouldProcess;
+	} catch (error) {
+		botLogger.error("Error in regular image detection", {
+			error: error.message,
+			chatId: ctx.chatId,
+			chatType: ctx.chatType
+		});
+		return false;
+	}
+}
+
+/**
+ * Processes and stores a regular image message
+ * @param {Object} ctx - The message context from Zaileys
+ */
+export async function storeRegularImage(ctx) {
+	try {
+		botLogger.processing("Processing regular image message", {
+			chatId: ctx.chatId,
+			roomId: ctx.roomId,
+			roomName: ctx.roomName,
+			senderName: ctx.senderName,
+			hasMedia: !!ctx.media
+		});
+
+		// Handle image saving using existing infrastructure
+		const imagePath = await handleImageMessage(ctx);
+		
+		if (imagePath) {
+			// Load existing messages for storage
+			botLogger.database("Loading existing messages for image update");
+			const messages = await loadMessages();
+			
+			// Create image message object
+			const imageData = {
+				// Main message metadata
+				chatId: ctx.chatId,
+				channelId: ctx.channelId,
+				uniqueId: ctx.uniqueId,
+				roomId: ctx.roomId,
+				roomName: ctx.roomName,
+				senderId: ctx.senderId,
+				senderName: ctx.senderName,
+				senderDevice: ctx.senderDevice,
+				timestamp: ctx.timestamp,
+				text: ctx.text || '',
+				isFromMe: ctx.isFromMe,
+				isGroup: ctx.isGroup,
+				
+				// Image specific data
+				chatType: ctx.chatType,
+				hasMedia: true,
+				imagePath: imagePath,
+				
+				// Media metadata
+				media: {
+					mimetype: ctx.media.mimetype,
+					caption: ctx.media.caption,
+					height: ctx.media.height,
+					width: ctx.media.width,
+					fileLength: ctx.media.fileLength
+				},
+				
+				// Processing metadata
+				processedAt: new Date().toISOString(),
+				contentType: 'regular_image',
+				
+				// Room/sender context
+				roomContext: {
+					roomId: ctx.roomId,
+					roomName: ctx.roomName,
+					isGroup: ctx.isGroup,
+					senderName: ctx.senderName
+				}
+			};
+			
+			// Add image to messages array and save
+			messages.push(imageData);
+			await saveMessages(messages);
+			
+			botLogger.success("Regular image stored successfully", {
+				totalMessages: messages.length,
+				roomName: ctx.roomName,
+				senderName: ctx.senderName,
+				imagePath: imagePath
+			});
+		} else {
+			botLogger.warning("Failed to save image file, skipping message storage");
+		}
+	} catch (error) {
+		botLogger.error("Error storing regular image", {
+			error: error.message,
+			chatId: ctx.chatId,
+			roomId: ctx.roomId,
+			roomName: ctx.roomName,
+			stack: error.stack
+		});
+	}
+}
+
+/**
+ * Handles incoming regular image messages
+ * @param {Object} ctx - The message context from Zaileys
+ * @param {Object} client - The WhatsApp client instance
+ */
+export async function handleRegularImageMessage(ctx, client) {
+	botLogger.messageReceived("Regular image message received", {
+		chatId: ctx.chatId,
+		roomId: ctx.roomId,
+		roomName: ctx.roomName,
+		senderName: ctx.senderName,
+		mediaType: ctx.chatType,
+		hasCaption: !!ctx.text,
+		caption: ctx.text || ''
+	});
+
+	// Process and store the regular image
+	if (detectRegularImageContent(ctx)) {
+		await storeRegularImage(ctx);
+	} else {
+		botLogger.debug("Image message does not meet regular image criteria, skipping");
+	}
+}

--- a/src/handlers/mediaHandler.js
+++ b/src/handlers/mediaHandler.js
@@ -16,27 +16,27 @@ const mbToBytes = (mb) => mb * 1024 * 1024;
 const MEDIA_CONFIG = {
 	image: {
 		enabled: true,
-		maxSize: mbToBytes(50), // 50MB
+		maxSize: mbToBytes(50),
 		formats: ['image/jpeg', 'image/jpg', 'image/png', 'image/gif', 'image/webp']
 	},
 	video: {
 		enabled: true,
-		maxSize: mbToBytes(100), // 100MB
+		maxSize: mbToBytes(100),
 		formats: ['video/mp4', 'video/avi', 'video/mov', 'video/mkv']
 	},
 	audio: {
 		enabled: true,
-		maxSize: mbToBytes(25), // 25MB
+		maxSize: mbToBytes(50),
 		formats: ['audio/mpeg', 'audio/mp4', 'audio/ogg', 'audio/wav', 'audio/m4a']
 	},
 	voice: {
 		enabled: true,
-		maxSize: mbToBytes(10), // 10MB
+		maxSize: mbToBytes(50),
 		formats: ['audio/ogg', 'audio/mp4', 'audio/mpeg']
 	},
 	document: {
 		enabled: true,
-		maxSize: mbToBytes(20), // 20MB
+		maxSize: mbToBytes(50),
 		formats: ['application/pdf', 'application/msword', 'application/vnd.openxmlformats-officedocument.wordprocessingml.document']
 	}
 };

--- a/src/handlers/mediaHandler.js
+++ b/src/handlers/mediaHandler.js
@@ -35,7 +35,7 @@ const MEDIA_CONFIG = {
 		formats: ['audio/ogg', 'audio/mp4', 'audio/mpeg']
 	},
 	document: {
-		enabled: false, // Disabled by default due to potential large files
+		enabled: true,
 		maxSize: mbToBytes(20), // 20MB
 		formats: ['application/pdf', 'application/msword', 'application/vnd.openxmlformats-officedocument.wordprocessingml.document']
 	}

--- a/src/handlers/mediaHandler.js
+++ b/src/handlers/mediaHandler.js
@@ -4,32 +4,39 @@ import { handleMediaMessage, getMediaFileExtension } from "../services/mediaHand
 import { shouldStoreImage } from "../config/imageConfig.js";
 
 /**
+ * Converts megabytes to bytes
+ * @param {number} mb - Size in megabytes
+ * @returns {number} Size in bytes
+ */
+const mbToBytes = (mb) => mb * 1024 * 1024;
+
+/**
  * Configuration for different media types
  */
 const MEDIA_CONFIG = {
 	image: {
 		enabled: true,
-		maxSize: 50 * 1024 * 1024, // 50MB
+		maxSize: mbToBytes(50), // 50MB
 		formats: ['image/jpeg', 'image/jpg', 'image/png', 'image/gif', 'image/webp']
 	},
 	video: {
 		enabled: true,
-		maxSize: 100 * 1024 * 1024, // 100MB
+		maxSize: mbToBytes(100), // 100MB
 		formats: ['video/mp4', 'video/avi', 'video/mov', 'video/mkv']
 	},
 	audio: {
 		enabled: true,
-		maxSize: 25 * 1024 * 1024, // 25MB
+		maxSize: mbToBytes(25), // 25MB
 		formats: ['audio/mpeg', 'audio/mp4', 'audio/ogg', 'audio/wav', 'audio/m4a']
 	},
 	voice: {
 		enabled: true,
-		maxSize: 10 * 1024 * 1024, // 10MB
+		maxSize: mbToBytes(10), // 10MB
 		formats: ['audio/ogg', 'audio/mp4', 'audio/mpeg']
 	},
 	document: {
 		enabled: false, // Disabled by default due to potential large files
-		maxSize: 20 * 1024 * 1024, // 20MB
+		maxSize: mbToBytes(20), // 20MB
 		formats: ['application/pdf', 'application/msword', 'application/vnd.openxmlformats-officedocument.wordprocessingml.document']
 	}
 };

--- a/src/handlers/mediaHandler.js
+++ b/src/handlers/mediaHandler.js
@@ -1,0 +1,254 @@
+import { botLogger } from "../../logger.js";
+import { loadMessages, saveMessages } from "../services/messageStorage.js";
+import { handleMediaMessage, getMediaFileExtension } from "../services/mediaHandler.js";
+import { shouldStoreImage } from "../config/imageConfig.js";
+
+/**
+ * Configuration for different media types
+ */
+const MEDIA_CONFIG = {
+	image: {
+		enabled: true,
+		maxSize: 50 * 1024 * 1024, // 50MB
+		formats: ['image/jpeg', 'image/jpg', 'image/png', 'image/gif', 'image/webp']
+	},
+	video: {
+		enabled: true,
+		maxSize: 100 * 1024 * 1024, // 100MB
+		formats: ['video/mp4', 'video/avi', 'video/mov', 'video/mkv']
+	},
+	audio: {
+		enabled: true,
+		maxSize: 25 * 1024 * 1024, // 25MB
+		formats: ['audio/mpeg', 'audio/mp4', 'audio/ogg', 'audio/wav', 'audio/m4a']
+	},
+	voice: {
+		enabled: true,
+		maxSize: 10 * 1024 * 1024, // 10MB
+		formats: ['audio/ogg', 'audio/mp4', 'audio/mpeg']
+	},
+	document: {
+		enabled: false, // Disabled by default due to potential large files
+		maxSize: 20 * 1024 * 1024, // 20MB
+		formats: ['application/pdf', 'application/msword', 'application/vnd.openxmlformats-officedocument.wordprocessingml.document']
+	}
+};
+
+/**
+ * Detects if a message contains media content that should be stored
+ * @param {Object} ctx - The message context from Zaileys
+ * @returns {boolean} True if media content should be stored
+ */
+export function detectMediaContent(ctx) {
+	try {
+		// Check if message has media
+		if (!ctx.media || !ctx.chatType) {
+			return false;
+		}
+
+		// Exclude view-once and stories (handled separately)
+		if (ctx.isViewOnce || ctx.media?.viewOnce || ctx.isStory || ctx.chatType === 'viewOnce') {
+			return false;
+		}
+
+		// Check if media type is supported
+		const mediaType = ctx.chatType;
+		const config = MEDIA_CONFIG[mediaType];
+		
+		if (!config || !config.enabled) {
+			botLogger.debug(`Media type ${mediaType} is not enabled for storage`);
+			return false;
+		}
+
+		// Check file size
+		if (ctx.media.fileLength && ctx.media.fileLength > config.maxSize) {
+			botLogger.debug(`Media file too large: ${ctx.media.fileLength} > ${config.maxSize}`);
+			return false;
+		}
+
+		// Check format
+		if (ctx.media.mimetype && config.formats.length > 0 && !config.formats.includes(ctx.media.mimetype)) {
+			botLogger.debug(`Media format not supported: ${ctx.media.mimetype}`);
+			return false;
+		}
+
+		// For images, also check the image-specific filters
+		if (mediaType === 'image') {
+			return shouldStoreImage(ctx);
+		}
+
+		botLogger.debug("Media content detection passed", {
+			chatId: ctx.chatId,
+			roomId: ctx.roomId,
+			mediaType,
+			mimetype: ctx.media.mimetype,
+			fileSize: ctx.media.fileLength
+		});
+
+		return true;
+	} catch (error) {
+		botLogger.error("Error in media content detection", {
+			error: error.message,
+			chatId: ctx.chatId,
+			chatType: ctx.chatType
+		});
+		return false;
+	}
+}
+
+/**
+ * Processes and stores a media message
+ * @param {Object} ctx - The message context from Zaileys
+ */
+export async function storeMediaMessage(ctx) {
+	try {
+		botLogger.processing(`Processing ${ctx.chatType} message`, {
+			chatId: ctx.chatId,
+			roomId: ctx.roomId,
+			roomName: ctx.roomName,
+			senderName: ctx.senderName,
+			mediaType: ctx.chatType,
+			hasMedia: !!ctx.media
+		});
+
+		// Handle media saving using enhanced infrastructure
+		const mediaPath = await handleMediaMessage(ctx);
+		
+		if (mediaPath) {
+			// Load existing messages for storage
+			botLogger.database(`Loading existing messages for ${ctx.chatType} update`);
+			const messages = await loadMessages();
+			
+			// Create media message object
+			const mediaData = {
+				// Main message metadata
+				chatId: ctx.chatId,
+				channelId: ctx.channelId,
+				uniqueId: ctx.uniqueId,
+				roomId: ctx.roomId,
+				roomName: ctx.roomName,
+				senderId: ctx.senderId,
+				senderName: ctx.senderName,
+				senderDevice: ctx.senderDevice,
+				timestamp: ctx.timestamp,
+				text: ctx.text || '',
+				isFromMe: ctx.isFromMe,
+				isGroup: ctx.isGroup,
+				
+				// Media specific data
+				chatType: ctx.chatType,
+				hasMedia: true,
+				mediaPath: mediaPath,
+				mediaType: ctx.chatType,
+				
+				// Media metadata
+				media: {
+					mimetype: ctx.media.mimetype,
+					caption: ctx.media.caption,
+					height: ctx.media.height,
+					width: ctx.media.width,
+					fileLength: ctx.media.fileLength,
+					duration: ctx.media.duration, // For audio/video
+					pages: ctx.media.pages, // For documents
+					fileName: ctx.media.fileName // For documents
+				},
+				
+				// Processing metadata
+				processedAt: new Date().toISOString(),
+				contentType: `regular_${ctx.chatType}`,
+				
+				// Room/sender context
+				roomContext: {
+					roomId: ctx.roomId,
+					roomName: ctx.roomName,
+					isGroup: ctx.isGroup,
+					senderName: ctx.senderName
+				}
+			};
+			
+			// Add media to messages array and save
+			messages.push(mediaData);
+			await saveMessages(messages);
+			
+			botLogger.success(`${ctx.chatType} stored successfully`, {
+				totalMessages: messages.length,
+				roomName: ctx.roomName,
+				senderName: ctx.senderName,
+				mediaPath: mediaPath,
+				mediaType: ctx.chatType
+			});
+		} else {
+			botLogger.warning(`Failed to save ${ctx.chatType} file, skipping message storage`);
+		}
+	} catch (error) {
+		botLogger.error(`Error storing ${ctx.chatType}`, {
+			error: error.message,
+			chatId: ctx.chatId,
+			roomId: ctx.roomId,
+			roomName: ctx.roomName,
+			mediaType: ctx.chatType,
+			stack: error.stack
+		});
+	}
+}
+
+/**
+ * Handles incoming media messages
+ * @param {Object} ctx - The message context from Zaileys
+ * @param {Object} client - The WhatsApp client instance
+ */
+export async function handleMediaMessageWrapper(ctx, client) {
+	botLogger.messageReceived(`${ctx.chatType} message received`, {
+		chatId: ctx.chatId,
+		roomId: ctx.roomId,
+		roomName: ctx.roomName,
+		senderName: ctx.senderName,
+		mediaType: ctx.chatType,
+		hasCaption: !!ctx.text,
+		caption: ctx.text || '',
+		fileSize: ctx.media?.fileLength || 0
+	});
+
+	// Process and store the media
+	if (detectMediaContent(ctx)) {
+		await storeMediaMessage(ctx);
+	} else {
+		botLogger.debug(`${ctx.chatType} message does not meet storage criteria, skipping`);
+	}
+}
+
+/**
+ * Get media storage statistics
+ * @returns {Object} Statistics about stored media
+ */
+export async function getMediaStorageStats() {
+	try {
+		const messages = await loadMessages();
+		const stats = {
+			total: messages.length,
+			byType: {},
+			byRoom: {},
+			totalSize: 0
+		};
+
+		messages.forEach(msg => {
+			// Count by content type
+			const contentType = msg.contentType || 'unknown';
+			stats.byType[contentType] = (stats.byType[contentType] || 0) + 1;
+
+			// Count by room
+			const roomName = msg.roomName || 'unknown';
+			stats.byRoom[roomName] = (stats.byRoom[roomName] || 0) + 1;
+
+			// Sum file sizes (if available)
+			if (msg.media?.fileLength) {
+				stats.totalSize += msg.media.fileLength;
+			}
+		});
+
+		return stats;
+	} catch (error) {
+		botLogger.error("Error getting media storage stats", { error: error.message });
+		return { total: 0, byType: {}, byRoom: {}, totalSize: 0 };
+	}
+}

--- a/src/handlers/messageHandler.js
+++ b/src/handlers/messageHandler.js
@@ -2,6 +2,7 @@ import { botLogger } from "../../logger.js";
 import { loadMessages, saveMessages } from "../services/messageStorage.js";
 import { detectViewOnceContent, handleRepliedMessage } from "../handlers/viewOnceHandler.js";
 import { detectStoryContent, handleStory } from "../handlers/storyHandler.js";
+import { detectMediaContent, handleMediaMessageWrapper } from "../handlers/mediaHandler.js";
 
 /**
  * Processes and stores a received message - only saves view once messages
@@ -107,6 +108,8 @@ export async function handleMessage(ctx, client) {
 		isEdited: ctx.isEdited,
 		isDeleted: ctx.isDeleted,
 		hasReplied: !!ctx.replied,
+		hasMedia: !!ctx.media,
+		chatType: ctx.chatType,
 		text: ctx.text || '',
 		messageTimestamp: ctx.timestamp
 	});
@@ -115,6 +118,12 @@ export async function handleMessage(ctx, client) {
 	if (detectStoryContent(ctx)) {
 		await handleStory(ctx, client);
 		return; // Stories are handled separately
+	}
+
+	// Handle regular media messages (images, videos, audio, documents)
+	if (detectMediaContent(ctx)) {
+		await handleMediaMessageWrapper(ctx, client);
+		return; // Media messages are handled separately
 	}
 
 	// Only process and store messages if they contain view once content

--- a/src/utils/mediaManager.js
+++ b/src/utils/mediaManager.js
@@ -64,11 +64,17 @@ export async function getStorageStatistics() {
 			stats.bySender[senderName].count++;
 
 			// Group by date
-			const date = new Date(msg.timestamp || msg.processedAt).toISOString().split('T')[0];
-			if (!stats.byDate[date]) {
-				stats.byDate[date] = { count: 0 };
+			const timestamp = msg.timestamp || msg.processedAt;
+			if (timestamp) {
+				const dateObj = new Date(timestamp);
+				if (!isNaN(dateObj.getTime())) {
+					const date = dateObj.toISOString().split('T')[0];
+					if (!stats.byDate[date]) {
+						stats.byDate[date] = { count: 0 };
+					}
+					stats.byDate[date].count++;
+				}
 			}
-			stats.byDate[date].count++;
 
 			// Add file size if available
 			const fileSize = msg.media?.fileLength || 0;
@@ -396,11 +402,11 @@ export async function exportMediaData(format = 'json') {
 			
 			mediaMessages.forEach(msg => {
 				const row = [
-					msg.timestamp || '',
+					escapeCsvField(msg.timestamp || ''),
 					escapeCsvField(msg.roomName || ''),
 					escapeCsvField(msg.senderName || ''),
-					msg.mediaType || msg.chatType || '',
-					msg.contentType || '',
+					escapeCsvField(msg.mediaType || msg.chatType || ''),
+					escapeCsvField(msg.contentType || ''),
 					msg.media?.fileLength || 0,
 					escapeCsvField(msg.mediaPath || msg.imagePath || msg.viewOnceImagePath || msg.storyMediaPath || ''),
 					escapeCsvField(msg.media?.caption || msg.text || ''),

--- a/src/utils/mediaManager.js
+++ b/src/utils/mediaManager.js
@@ -1,0 +1,394 @@
+import fs from "fs/promises";
+import path from "path";
+import { loadMessages } from "../services/messageStorage.js";
+import { botLogger } from "../../logger.js";
+
+/**
+ * Media Storage Management Utilities
+ */
+
+/**
+ * Get comprehensive storage statistics
+ * @returns {Promise<Object>} Detailed storage statistics
+ */
+export async function getStorageStatistics() {
+	try {
+		const messages = await loadMessages();
+		const stats = {
+			overview: {
+				totalMessages: messages.length,
+				messagesWithMedia: 0,
+				totalEstimatedSize: 0
+			},
+			byContentType: {},
+			byMediaType: {},
+			byRoom: {},
+			bySender: {},
+			byDate: {},
+			recentActivity: []
+		};
+
+		// Process each message
+		for (const msg of messages) {
+			// Count messages with media
+			if (msg.hasMedia || msg.imagePath || msg.mediaPath || msg.viewOnceImagePath || msg.storyMediaPath) {
+				stats.overview.messagesWithMedia++;
+			}
+
+			// Group by content type
+			const contentType = msg.contentType || 'unknown';
+			if (!stats.byContentType[contentType]) {
+				stats.byContentType[contentType] = { count: 0, totalSize: 0 };
+			}
+			stats.byContentType[contentType].count++;
+
+			// Group by media type
+			const mediaType = msg.mediaType || msg.chatType || 'unknown';
+			if (!stats.byMediaType[mediaType]) {
+				stats.byMediaType[mediaType] = { count: 0, totalSize: 0 };
+			}
+			stats.byMediaType[mediaType].count++;
+
+			// Group by room
+			const roomName = msg.roomName || msg.roomId || 'unknown';
+			if (!stats.byRoom[roomName]) {
+				stats.byRoom[roomName] = { count: 0, isGroup: msg.isGroup };
+			}
+			stats.byRoom[roomName].count++;
+
+			// Group by sender
+			const senderName = msg.senderName || 'unknown';
+			if (!stats.bySender[senderName]) {
+				stats.bySender[senderName] = { count: 0 };
+			}
+			stats.bySender[senderName].count++;
+
+			// Group by date
+			const date = new Date(msg.timestamp || msg.processedAt).toISOString().split('T')[0];
+			if (!stats.byDate[date]) {
+				stats.byDate[date] = { count: 0 };
+			}
+			stats.byDate[date].count++;
+
+			// Add file size if available
+			const fileSize = msg.media?.fileLength || 0;
+			if (fileSize > 0) {
+				stats.overview.totalEstimatedSize += fileSize;
+				stats.byContentType[contentType].totalSize += fileSize;
+				stats.byMediaType[mediaType].totalSize += fileSize;
+			}
+
+			// Track recent activity (last 10 messages)
+			if (stats.recentActivity.length < 10) {
+				stats.recentActivity.push({
+					timestamp: msg.timestamp || msg.processedAt,
+					roomName: msg.roomName,
+					senderName: msg.senderName,
+					mediaType: mediaType,
+					hasMedia: !!(msg.hasMedia || msg.imagePath || msg.mediaPath)
+				});
+			}
+		}
+
+		// Sort recent activity by timestamp
+		stats.recentActivity.sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp));
+
+		return stats;
+	} catch (error) {
+		botLogger.error("Error getting storage statistics", { error: error.message });
+		throw error;
+	}
+}
+
+/**
+ * Get directory size for a specific path
+ * @param {string} dirPath - Directory path to analyze
+ * @returns {Promise<Object>} Directory size information
+ */
+export async function getDirectorySize(dirPath) {
+	try {
+		let totalSize = 0;
+		let fileCount = 0;
+
+		async function scanDirectory(currentPath) {
+			const items = await fs.readdir(currentPath, { withFileTypes: true });
+			
+			for (const item of items) {
+				const fullPath = path.join(currentPath, item.name);
+				
+				if (item.isDirectory()) {
+					await scanDirectory(fullPath);
+				} else if (item.isFile()) {
+					const stats = await fs.stat(fullPath);
+					totalSize += stats.size;
+					fileCount++;
+				}
+			}
+		}
+
+		await scanDirectory(dirPath);
+
+		return {
+			path: dirPath,
+			totalSize,
+			fileCount,
+			formattedSize: formatBytes(totalSize)
+		};
+	} catch (error) {
+		return {
+			path: dirPath,
+			totalSize: 0,
+			fileCount: 0,
+			formattedSize: '0 B',
+			error: error.message
+		};
+	}
+}
+
+/**
+ * Get comprehensive directory analysis
+ * @returns {Promise<Object>} Directory analysis for all media folders
+ */
+export async function analyzeMediaDirectories() {
+	const directories = [
+		'./data/images',
+		'./data/viewonce', 
+		'./data/stories',
+		'./data/media'
+	];
+
+	const analysis = {
+		overview: {
+			totalSize: 0,
+			totalFiles: 0
+		},
+		directories: {}
+	};
+
+	for (const dir of directories) {
+		try {
+			const dirInfo = await getDirectorySize(dir);
+			analysis.directories[dir] = dirInfo;
+			analysis.overview.totalSize += dirInfo.totalSize;
+			analysis.overview.totalFiles += dirInfo.fileCount;
+		} catch (error) {
+			analysis.directories[dir] = {
+				path: dir,
+				totalSize: 0,
+				fileCount: 0,
+				formattedSize: '0 B',
+				error: error.message
+			};
+		}
+	}
+
+	analysis.overview.formattedSize = formatBytes(analysis.overview.totalSize);
+	return analysis;
+}
+
+/**
+ * Clean up old media files based on age
+ * @param {number} daysOld - Remove files older than this many days
+ * @param {boolean} dryRun - If true, only report what would be deleted
+ * @returns {Promise<Object>} Cleanup results
+ */
+export async function cleanupOldMedia(daysOld = 30, dryRun = true) {
+	const cutoffDate = new Date();
+	cutoffDate.setDate(cutoffDate.getDate() - daysOld);
+
+	const results = {
+		scanned: 0,
+		toDelete: 0,
+		deletedFiles: [],
+		errors: [],
+		estimatedSpaceSaved: 0
+	};
+
+	const directories = [
+		'./data/images',
+		'./data/viewonce',
+		'./data/stories',
+		'./data/media'
+	];
+
+	async function scanDirectory(dirPath) {
+		try {
+			const items = await fs.readdir(dirPath, { withFileTypes: true });
+			
+			for (const item of items) {
+				const fullPath = path.join(dirPath, item.name);
+				
+				if (item.isDirectory()) {
+					await scanDirectory(fullPath);
+				} else if (item.isFile()) {
+					results.scanned++;
+					const stats = await fs.stat(fullPath);
+					
+					if (stats.mtime < cutoffDate) {
+						results.toDelete++;
+						results.estimatedSpaceSaved += stats.size;
+						
+						if (!dryRun) {
+							try {
+								await fs.unlink(fullPath);
+								results.deletedFiles.push(fullPath);
+								botLogger.info(`Deleted old file: ${fullPath}`);
+							} catch (deleteError) {
+								results.errors.push({
+									file: fullPath,
+									error: deleteError.message
+								});
+							}
+						}
+					}
+				}
+			}
+		} catch (error) {
+			results.errors.push({
+				directory: dirPath,
+				error: error.message
+			});
+		}
+	}
+
+	for (const dir of directories) {
+		await scanDirectory(dir);
+	}
+
+	return {
+		...results,
+		dryRun,
+		cutoffDate: cutoffDate.toISOString(),
+		formattedSpaceSaved: formatBytes(results.estimatedSpaceSaved)
+	};
+}
+
+/**
+ * Find duplicate media files
+ * @returns {Promise<Object>} Duplicate analysis results
+ */
+export async function findDuplicateMedia() {
+	const duplicates = {
+		bySizeAndName: {},
+		potentialDuplicates: [],
+		totalDuplicateSize: 0
+	};
+
+	const directories = [
+		'./data/images',
+		'./data/viewonce',
+		'./data/stories', 
+		'./data/media'
+	];
+
+	async function scanForDuplicates(dirPath) {
+		try {
+			const items = await fs.readdir(dirPath, { withFileTypes: true });
+			
+			for (const item of items) {
+				const fullPath = path.join(dirPath, item.name);
+				
+				if (item.isDirectory()) {
+					await scanForDuplicates(fullPath);
+				} else if (item.isFile()) {
+					const stats = await fs.stat(fullPath);
+					const key = `${item.name}_${stats.size}`;
+					
+					if (!duplicates.bySizeAndName[key]) {
+						duplicates.bySizeAndName[key] = [];
+					}
+					
+					duplicates.bySizeAndName[key].push({
+						path: fullPath,
+						size: stats.size,
+						mtime: stats.mtime
+					});
+				}
+			}
+		} catch (error) {
+			botLogger.error("Error scanning for duplicates", { error: error.message, dirPath });
+		}
+	}
+
+	for (const dir of directories) {
+		await scanForDuplicates(dir);
+	}
+
+	// Find actual duplicates
+	for (const [key, files] of Object.entries(duplicates.bySizeAndName)) {
+		if (files.length > 1) {
+			duplicates.potentialDuplicates.push({
+				key,
+				files,
+				duplicateCount: files.length - 1,
+				wastedSpace: files[0].size * (files.length - 1)
+			});
+			duplicates.totalDuplicateSize += files[0].size * (files.length - 1);
+		}
+	}
+
+	delete duplicates.bySizeAndName; // Remove to reduce output size
+
+	return {
+		...duplicates,
+		formattedTotalWaste: formatBytes(duplicates.totalDuplicateSize)
+	};
+}
+
+/**
+ * Format bytes to human readable format
+ * @param {number} bytes - Bytes to format
+ * @returns {string} Formatted string
+ */
+function formatBytes(bytes) {
+	if (bytes === 0) return '0 B';
+	const k = 1024;
+	const sizes = ['B', 'KB', 'MB', 'GB'];
+	const i = Math.floor(Math.log(bytes) / Math.log(k));
+	return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
+}
+
+/**
+ * Export media data for external analysis
+ * @param {string} format - Export format ('json' or 'csv')
+ * @returns {Promise<string>} Export data as string
+ */
+export async function exportMediaData(format = 'json') {
+	try {
+		const messages = await loadMessages();
+		const mediaMessages = messages.filter(msg => 
+			msg.hasMedia || msg.imagePath || msg.mediaPath || msg.viewOnceImagePath || msg.storyMediaPath
+		);
+
+		if (format === 'csv') {
+			const headers = [
+				'timestamp', 'roomName', 'senderName', 'mediaType', 'contentType',
+				'fileSize', 'mediaPath', 'caption', 'isGroup'
+			];
+			
+			const csvRows = [headers.join(',')];
+			
+			mediaMessages.forEach(msg => {
+				const row = [
+					msg.timestamp || '',
+					`"${msg.roomName || ''}"`,
+					`"${msg.senderName || ''}"`,
+					msg.mediaType || msg.chatType || '',
+					msg.contentType || '',
+					msg.media?.fileLength || 0,
+					`"${msg.mediaPath || msg.imagePath || msg.viewOnceImagePath || msg.storyMediaPath || ''}"`,
+					`"${msg.media?.caption || msg.text || ''}"`,
+					msg.isGroup || false
+				];
+				csvRows.push(row.join(','));
+			});
+			
+			return csvRows.join('\n');
+		} else {
+			return JSON.stringify(mediaMessages, null, 2);
+		}
+	} catch (error) {
+		botLogger.error("Error exporting media data", { error: error.message });
+		throw error;
+	}
+}

--- a/src/utils/mediaManager.js
+++ b/src/utils/mediaManager.js
@@ -8,6 +8,17 @@ import { botLogger } from "../../logger.js";
  */
 
 /**
+ * Media directories that are managed by this system
+ * @constant {string[]}
+ */
+const MEDIA_DIRECTORIES = [
+	'./data/images',
+	'./data/viewonce', 
+	'./data/stories',
+	'./data/media'
+];
+
+/**
  * Get comprehensive storage statistics
  * @returns {Promise<Object>} Detailed storage statistics
  */
@@ -162,13 +173,6 @@ export async function getDirectorySize(dirPath) {
  * @returns {Promise<Object>} Directory analysis for all media folders
  */
 export async function analyzeMediaDirectories() {
-	const directories = [
-		'./data/images',
-		'./data/viewonce', 
-		'./data/stories',
-		'./data/media'
-	];
-
 	const analysis = {
 		overview: {
 			totalSize: 0,
@@ -177,7 +181,7 @@ export async function analyzeMediaDirectories() {
 		directories: {}
 	};
 
-	for (const dir of directories) {
+	for (const dir of MEDIA_DIRECTORIES) {
 		try {
 			const dirInfo = await getDirectorySize(dir);
 			analysis.directories[dir] = dirInfo;
@@ -215,13 +219,6 @@ export async function cleanupOldMedia(daysOld = 30, dryRun = true) {
 		errors: [],
 		estimatedSpaceSaved: 0
 	};
-
-	const directories = [
-		'./data/images',
-		'./data/viewonce',
-		'./data/stories',
-		'./data/media'
-	];
 
 	async function scanDirectory(dirPath) {
 		try {
@@ -269,7 +266,7 @@ export async function cleanupOldMedia(daysOld = 30, dryRun = true) {
 		}
 	}
 
-	for (const dir of directories) {
+	for (const dir of MEDIA_DIRECTORIES) {
 		await scanDirectory(dir);
 	}
 
@@ -291,13 +288,6 @@ export async function findDuplicateMedia() {
 		potentialDuplicates: [],
 		totalDuplicateSize: 0
 	};
-
-	const directories = [
-		'./data/images',
-		'./data/viewonce',
-		'./data/stories', 
-		'./data/media'
-	];
 
 	async function scanForDuplicates(dirPath) {
 		try {
@@ -334,7 +324,7 @@ export async function findDuplicateMedia() {
 		}
 	}
 
-	for (const dir of directories) {
+	for (const dir of MEDIA_DIRECTORIES) {
 		await scanForDuplicates(dir);
 	}
 


### PR DESCRIPTION
Instead of just capturing view once message from reply, it now capture all media automatically. The view once is left untouched since it requires replying to

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced comprehensive image and media storage for the WhatsApp Stealth Companion bot, supporting images, videos, audio, documents, voice notes, view-once images, and stories, organized by room or sender.
  * Added configuration options to enable/disable specific media types, set file size limits, and filter by room, sender, or chat type.
  * Provided a CLI tool for managing media storage, including viewing statistics, analyzing storage, cleaning up old files, finding duplicates, and exporting metadata.
  * Enhanced message handling to process and store media files with detailed metadata and robust error handling.

* **Documentation**
  * Added a detailed guide on configuring, customizing, and managing image and media storage, including troubleshooting and migration instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->