### PR TITLE
fix audio files aren't captured

### DIFF
--- a/src/services/mediaHandler.js
+++ b/src/services/mediaHandler.js
@@ -156,6 +156,9 @@ export function getMediaFileExtension(chatType, mimetype) {
 	try {
 		// Extract extension from mimetype if available
 		if (mimetype) {
+			// Handle mimetypes with additional parameters (e.g., "audio/ogg; codecs=opus")
+			const baseMimetype = mimetype.split(';')[0].trim();
+
 			const mimeExtensionMap = {
 				'image/jpeg': 'jpg',
 				'image/jpg': 'jpg',
@@ -170,13 +173,13 @@ export function getMediaFileExtension(chatType, mimetype) {
 				'audio/ogg': 'ogg',
 				'audio/wav': 'wav'
 			};
-			
-			if (mimeExtensionMap[mimetype]) {
-				return mimeExtensionMap[mimetype];
+
+			if (mimeExtensionMap[baseMimetype]) {
+				return mimeExtensionMap[baseMimetype];
 			}
-			
+
 			// Fallback: try to extract from mimetype string
-			const parts = mimetype.split('/');
+			const parts = baseMimetype.split('/');
 			if (parts.length === 2) {
 				return parts[1];
 			}


### PR DESCRIPTION
- Fix mimetype detection to handle formats like 'audio/ogg; codecs=opus'
- Extract base mimetype by splitting on semicolon before format validation
- Fix file size handling for Long integer types from WhatsApp libraries
- Update getMediaFileExtension to handle codec parameters properly
- Audio files should now be properly detected and downloaded

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file size validation to handle multiple data types and ensure accurate checks against maximum limits.
  * Enhanced media format validation to correctly process MIME types with additional parameters.
  * Improved file extension detection for media files by handling MIME types with extra parameters, ensuring reliable file handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->