### PR TITLE
Correct ctx schema (types and inferences) to match the actual ctx object returned as defined in zaileys docs

### DIFF
--- a/.augment/rules/ctx-schema.md
+++ b/.augment/rules/ctx-schema.md
@@ -1,0 +1,264 @@
+---
+type: "manual"
+---
+
+# Zaileys Context Object (ctx) Schema
+
+This document provides a comprehensive schema for the `ctx` object that is sent to users when a message arrives in the Zaileys WhatsApp library.
+
+## Overview
+
+The `ctx` object is passed to the `messages` event handler and contains all information about the received message, sender, receiver, and various metadata flags.
+
+```typescript
+wa.on("messages", (ctx) => {
+  // ctx contains all message information
+  console.log(ctx);
+});
+```
+
+## Complete Schema
+
+### Core Identifiers
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `chatId` | `string` | Unique identifier for the specific message |
+| `channelId` | `string` | Combined identifier: `roomId-senderId` (without @domain) |
+| `uniqueId` | `string` | Unique identifier: `channelId-chatId` |
+
+### Participant Information
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `receiverId` | `string` | WhatsApp ID of the bot/receiver (normalized) |
+| `receiverName` | `string` | Display name of the bot/receiver |
+| `roomId` | `string` | WhatsApp ID of the chat room (normalized) |
+| `roomName` | `string` | Display name of the chat room |
+| `senderId` | `string` | WhatsApp ID of the message sender (normalized) |
+| `senderName` | `string` | Display name of the message sender |
+| `senderDevice` | `"unknown" \| "android" \| "ios" \| "desktop" \| "web"` | Device type of the sender |
+
+### Message Content
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `chatType` | `MessageType` | Type of message content (see Message Types below) |
+| `timestamp` | `number` | Unix timestamp of the message |
+| `text` | `string \| null` | Text content of the message (extracted from various message types) |
+| `mentions` | `string[]` | Array of mentioned user IDs (without @domain) |
+| `links` | `string[]` | Array of URLs found in the message text |
+
+### Boolean Flags
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `isPrefix` | `boolean` | Whether message starts with configured prefix |
+| `isSpam` | `boolean` | Whether message is detected as spam (rate limited) |
+| `isFromMe` | `boolean` | Whether message was sent by the bot itself |
+| `isTagMe` | `boolean` | Whether the bot is mentioned in the message |
+| `isGroup` | `boolean` | Whether message is from a group chat (`@g.us`) |
+| `isStory` | `boolean` | Whether message is from status/story (`@broadcast`) |
+| `isViewOnce` | `boolean` | Whether message is a view-once message |
+| `isEdited` | `boolean` | Whether message has been edited |
+| `isDeleted` | `boolean` | Whether message has been deleted |
+| `isPinned` | `boolean` | Whether message has been pinned |
+| `isUnPinned` | `boolean` | Whether message has been unpinned |
+| `isChannel` | `boolean` | Whether message is from a channel (`@newsletter`) |
+| `isBroadcast` | `boolean` | Whether message is a broadcast message |
+| `isEphemeral` | `boolean` | Whether message is ephemeral (disappearing) |
+| `isForwarded` | `boolean` | Whether message has been forwarded |
+
+### Special Objects
+
+#### Citation Object
+```typescript
+citation: Record<string, boolean> | null
+```
+
+Dynamic object containing custom boolean flags based on client configuration. Keys are transformed from citation config:
+- `admins: () => [...]` becomes `citation.isAdmins`
+- `vips: () => [...]` becomes `citation.isVips`
+- `premiumUsers: () => [...]` becomes `citation.isPremiumUsers`
+
+Example:
+```typescript
+const wa = new Client({
+  citation: {
+    admins: () => [628123456789],
+    vips: () => [628123456789],
+  },
+});
+
+// In message handler:
+if (ctx.citation?.isAdmins) {
+  // Handle admin user
+}
+```
+
+#### Media Object
+```typescript
+media: {
+  // Media metadata (varies by type)
+  mimetype?: string;
+  fileSha256?: Buffer;
+  fileLength?: number;
+  seconds?: number; // for audio/video
+  width?: number; // for images/videos
+  height?: number; // for images/videos
+  caption?: string;
+  // ... other media-specific properties
+  
+  // Methods to access media content
+  buffer: () => Promise<Buffer>;
+  stream: () => Promise<Readable>;
+} | null
+```
+
+Available when `chatType` is not "text". Contains media metadata and methods to download content.
+
+#### Replied Object
+```typescript
+replied: ContextObject | null
+```
+
+When the message is a reply, contains the complete context object of the replied message (same schema as main ctx).
+
+#### Message Function
+```typescript
+message: () => proto.IWebMessageInfo
+```
+
+Function that returns the original raw WhatsApp message object from Baileys.
+
+## Message Types
+
+The `chatType` property can be one of the following values:
+
+### Text Messages
+- `"text"` - Plain text, conversation, edited messages, newsletter admin invites, extended text
+
+### Media Messages
+- `"image"` - Image messages
+- `"video"` - Video messages  
+- `"audio"` - Audio messages
+- `"document"` - Document messages
+- `"sticker"` - Sticker messages
+- `"ptv"` - Picture-in-picture video messages
+
+### Interactive Messages
+- `"contact"` - Contact card messages
+- `"location"` - Location messages
+- `"liveLocation"` - Live location messages
+- `"list"` - List messages
+- `"listResponse"` - List response messages
+- `"buttons"` - Button messages
+- `"buttonsResponse"` - Button response messages
+- `"interactive"` - Interactive messages
+- `"interactiveResponse"` - Interactive response messages
+- `"template"` - Template messages
+- `"templateButtonReply"` - Template button reply messages
+
+### Poll Messages
+- `"pollCreation"` - Poll creation messages
+- `"pollUpdate"` - Poll update messages
+
+### Special Messages
+- `"reaction"` - Reaction messages
+- `"viewOnce"` - View once messages
+- `"ephemeral"` - Ephemeral messages
+- `"protocol"` - Protocol messages
+- `"groupInvite"` - Group invite messages
+- `"product"` - Product messages
+- `"order"` - Order messages
+- `"invoice"` - Invoice messages
+- `"event"` - Event messages
+- `"comment"` - Comment messages
+- `"callLog"` - Call log messages
+
+### System Messages
+- `"deviceSent"` - Device sent messages
+- `"contactsArray"` - Contacts array messages
+- `"highlyStructured"` - Highly structured messages
+- `"sendPayment"` - Send payment messages
+- `"requestPayment"` - Request payment messages
+- `"declinePaymentRequest"` - Decline payment request messages
+- `"cancelPaymentRequest"` - Cancel payment request messages
+- `"paymentInvite"` - Payment invite messages
+- `"keepInChat"` - Keep in chat messages
+- `"requestPhoneNumber"` - Request phone number messages
+- `"groupMentioned"` - Group mentioned messages
+- `"pinInChat"` - Pin in chat messages
+- `"scheduledCallCreation"` - Scheduled call creation messages
+- `"scheduledCallEdit"` - Scheduled call edit messages
+- `"botInvoke"` - Bot invoke messages
+- `"encComment"` - Encrypted comment messages
+- `"bcall"` - Business call messages
+- `"lottieSticker"` - Lottie sticker messages
+- `"placeholder"` - Placeholder messages
+- `"encEventUpdate"` - Encrypted event update messages
+
+## Usage Examples
+
+### Basic Message Handling
+```typescript
+wa.on("messages", (ctx) => {
+  if (ctx.text === "hello") {
+    wa.text("Hello back!", { roomId: ctx.roomId });
+  }
+});
+```
+
+### Handling Media Messages
+```typescript
+wa.on("messages", async (ctx) => {
+  if (ctx.chatType === "image") {
+    const buffer = await ctx.media?.buffer();
+    // Process image buffer
+  }
+});
+```
+
+### Using Citation System
+```typescript
+wa.on("messages", (ctx) => {
+  if (ctx.citation?.isAdmins) {
+    wa.text("Admin command executed", { roomId: ctx.roomId });
+  }
+});
+```
+
+### Handling Replies
+```typescript
+wa.on("messages", (ctx) => {
+  if (ctx.replied) {
+    wa.text(`You replied to: ${ctx.replied.text}`, { roomId: ctx.roomId });
+  }
+});
+```
+
+### Group vs Private Chat
+```typescript
+wa.on("messages", (ctx) => {
+  if (ctx.isGroup) {
+    // Handle group message
+    if (ctx.isTagMe) {
+      wa.text("You mentioned me!", { roomId: ctx.roomId });
+    }
+  } else {
+    // Handle private message
+    wa.text("Private message received", { roomId: ctx.roomId });
+  }
+});
+```
+
+## TypeScript Type Definition
+
+```typescript
+import { z } from "zod";
+import { MessagesParserType } from "zaileys";
+
+type MessageContext = z.infer<typeof MessagesParserType>;
+```
+
+This schema represents the complete structure of the context object passed to message event handlers in the Zaileys WhatsApp library.

--- a/docs/CONNECTION_IMPROVEMENTS.md
+++ b/docs/CONNECTION_IMPROVEMENTS.md
@@ -53,7 +53,7 @@ const MIN_CONNECTION_INTERVAL = 5000; // 5 seconds
 ### 3. **Proper Status Handling**
 - Added support for Zaileys' actual status values: 'open' and 'close'
 - Updated TypeScript types to include correct status values
-- Handles both primary and alternative status names
+- Handles all possible connection status values from the library
 
 ### 4. **Separated Timeout Management**
 ```typescript
@@ -102,7 +102,7 @@ let lastConnectingEvent: number = 0;
 - Properly handles 'open' and 'close' status from Zaileys
 - Updates connection state variables
 - Prevents duplicate operations
-- Handles alternative status names
+- Handles all connection status values from the library
 
 ## 📊 Expected Improvements
 

--- a/docs/CONNECTION_IMPROVEMENTS.md
+++ b/docs/CONNECTION_IMPROVEMENTS.md
@@ -53,7 +53,7 @@ const MIN_CONNECTION_INTERVAL = 5000; // 5 seconds
 ### 3. **Proper Status Handling**
 - Added support for Zaileys' actual status values: 'open' and 'close'
 - Updated TypeScript types to include correct status values
-- Maintained backward compatibility with legacy status names
+- Handles both primary and alternative status names
 
 ### 4. **Separated Timeout Management**
 ```typescript
@@ -102,7 +102,7 @@ let lastConnectingEvent: number = 0;
 - Properly handles 'open' and 'close' status from Zaileys
 - Updates connection state variables
 - Prevents duplicate operations
-- Maintains backward compatibility
+- Handles alternative status names
 
 ## 📊 Expected Improvements
 

--- a/docs/STORY_FEATURE_SUMMARY.md
+++ b/docs/STORY_FEATURE_SUMMARY.md
@@ -39,7 +39,7 @@
 ### **Message Storage Integration**
 - Stories are saved to the same `messages.json` file
 - Story data includes all standard message metadata plus story-specific fields
-- Maintains backward compatibility with existing message structure
+- Uses consistent message structure with other message types
 
 ### **Logging Integration**
 - Uses existing `botLogger` methods

--- a/docs/VIEW_ONCE_IMPROVEMENTS.md
+++ b/docs/VIEW_ONCE_IMPROVEMENTS.md
@@ -38,7 +38,7 @@ data/viewonce/
 ### 5. **Updated Data Structure**
 - **Old**: `viewOnceImagePath` (image-specific)
 - **New**: `viewOnceMediaPath` + `viewOnceMediaType` (generic)
-- Backward compatibility maintained in utility functions
+- Consistent structure maintained across utility functions
 
 ## 📁 Files Modified
 
@@ -51,18 +51,18 @@ data/viewonce/
 ### Media Services
 - **`src/services/mediaHandler.js`**
   - Added `saveViewOnceMedia()` function
-  - Maintains existing `saveViewOnceImage()` for compatibility
+  - Maintains existing `saveViewOnceImage()` function
   - Enhanced directory organization by media type
 
 ### Message Processing
 - **`src/handlers/messageHandler.js`**
-  - Updated to use new property names
+  - Updated to use complete property set
   - Enhanced logging with media type information
 
 ### Utilities
 - **`src/utils/mediaManager.js`**
-  - Updated to support both old and new property names
-  - Maintains backward compatibility
+  - Updated to support comprehensive property access
+  - Handles all media types consistently
 
 ## 🧪 Testing Results
 
@@ -82,17 +82,17 @@ All functionality has been thoroughly tested:
 - **Edge Cases**: Unknown types, missing mimetypes
 - **Negative Cases**: Non-view-once content properly ignored
 
-## 🔄 Migration & Compatibility
+## 🔄 Implementation Details
 
-### Backward Compatibility
-- Existing `viewOnceImagePath` references maintained in utilities
-- Old data structure continues to work
-- No breaking changes to existing functionality
-
-### New Features
-- Media type information now stored with each view once message
-- Better organization of saved media files
+### Data Structure
+- Media type information is stored with each view once message
+- Better organization of saved media files by type
 - Enhanced logging with media type details
+
+### Features
+- Existing `viewOnceImagePath` references maintained in utilities
+- Consistent data structure across all media types
+- Comprehensive error handling and logging
 
 ## 🎉 Benefits
 

--- a/src/handlers/connectionHandler.ts
+++ b/src/handlers/connectionHandler.ts
@@ -158,7 +158,7 @@ async function performReconnection(): Promise<void> {
 }
 
 /**
- * Alternative function name that delegates to scheduleReconnection
+ * Schedules a reconnection attempt with exponential backoff
  * @returns {Promise<void>}
  */
 export async function attemptReconnection(): Promise<void> {
@@ -225,9 +225,7 @@ export async function handleConnection(ctx: ConnectionContext): Promise<void> {
 			}
 			break;
 
-		// Handle alternative status names
 		case 'connected':
-			// Treat same as 'open'
 			botLogger.success("✅ Successfully connected to WhatsApp!");
 			clearConnectionTimeout();
 			clearReconnectionTimeout();
@@ -237,7 +235,6 @@ export async function handleConnection(ctx: ConnectionContext): Promise<void> {
 			break;
 
 		case 'disconnected':
-			// Treat same as 'close'
 			botLogger.warning("⚠️ WhatsApp connection closed");
 			isConnected = false;
 			clearConnectionTimeout();

--- a/src/handlers/connectionHandler.ts
+++ b/src/handlers/connectionHandler.ts
@@ -158,7 +158,7 @@ async function performReconnection(): Promise<void> {
 }
 
 /**
- * Legacy function for backward compatibility - now delegates to scheduleReconnection
+ * Alternative function name that delegates to scheduleReconnection
  * @returns {Promise<void>}
  */
 export async function attemptReconnection(): Promise<void> {
@@ -225,7 +225,7 @@ export async function handleConnection(ctx: ConnectionContext): Promise<void> {
 			}
 			break;
 
-		// Handle legacy status names for backward compatibility
+		// Handle alternative status names
 		case 'connected':
 			// Treat same as 'open'
 			botLogger.success("✅ Successfully connected to WhatsApp!");

--- a/src/handlers/connectionHandler.ts
+++ b/src/handlers/connectionHandler.ts
@@ -158,14 +158,6 @@ async function performReconnection(): Promise<void> {
 }
 
 /**
- * Schedules a reconnection attempt with exponential backoff
- * @returns {Promise<void>}
- */
-export async function attemptReconnection(): Promise<void> {
-	scheduleReconnection();
-}
-
-/**
  * Handles connection status changes with robust monitoring
  * @param {Object} ctx - The connection context from Zaileys
  */

--- a/src/handlers/mediaHandler.ts
+++ b/src/handlers/mediaHandler.ts
@@ -55,6 +55,11 @@ const MEDIA_CONFIG: Record<SupportedMediaType, MediaConfig> = {
 		enabled: true,
 		maxSize: mbToBytes(10),
 		formats: ['image/webp', 'image/png', 'image/jpeg']
+	},
+	ptv: {
+		enabled: true,
+		maxSize: mbToBytes(100),
+		formats: ['video/mp4', 'video/avi', 'video/mov', 'video/mkv']
 	}
 };
 
@@ -159,18 +164,37 @@ export async function storeMediaMessage(ctx: MessageContext): Promise<void> {
 			const mediaData: StoredMediaMessage = {
 				// Main message metadata
 				chatId: ctx.chatId,
-				...(ctx.channelId && { channelId: ctx.channelId }),
-				...(ctx.uniqueId && { uniqueId: ctx.uniqueId }),
+				channelId: ctx.channelId,
+				uniqueId: ctx.uniqueId,
 				roomId: ctx.roomId,
 				roomName: ctx.roomName,
 				senderId: ctx.senderId,
 				senderName: ctx.senderName,
-				...(ctx.senderDevice && { senderDevice: ctx.senderDevice }),
+				senderDevice: ctx.senderDevice,
 				timestamp: ctx.timestamp,
-				...(ctx.text && { text: ctx.text }),
-				...(ctx.isFromMe !== undefined && { isFromMe: ctx.isFromMe }),
+				text: ctx.text,
+				isFromMe: ctx.isFromMe,
 				isGroup: ctx.isGroup,
-				
+
+				// All required fields from BaseStoredMessage
+				receiverId: ctx.receiverId,
+				receiverName: ctx.receiverName,
+				mentions: ctx.mentions,
+				links: ctx.links,
+				isPrefix: ctx.isPrefix,
+				isSpam: ctx.isSpam,
+				isTagMe: ctx.isTagMe,
+				isStory: ctx.isStory,
+				isViewOnce: ctx.isViewOnce,
+				isEdited: ctx.isEdited,
+				isDeleted: ctx.isDeleted,
+				isPinned: ctx.isPinned,
+				isUnPinned: ctx.isUnPinned,
+				isChannel: ctx.isChannel,
+				isBroadcast: ctx.isBroadcast,
+				isEphemeral: ctx.isEphemeral,
+				isForwarded: ctx.isForwarded,
+
 				// Media specific data
 				chatType: ctx.chatType,
 				hasMedia: true,
@@ -199,7 +223,8 @@ export async function storeMediaMessage(ctx: MessageContext): Promise<void> {
 					roomId: ctx.roomId,
 					roomName: ctx.roomName,
 					isGroup: ctx.isGroup,
-					senderName: ctx.senderName
+					senderName: ctx.senderName,
+					senderDevice: ctx.senderDevice
 				}
 			};
 			

--- a/src/handlers/messageHandler.ts
+++ b/src/handlers/messageHandler.ts
@@ -3,7 +3,7 @@ import { loadMessages, saveMessages } from "../services/messageStorage.js";
 import { detectViewOnceContent, handleRepliedMessage } from "../handlers/viewOnceHandler.js";
 import { detectStoryContent, handleStory } from "../handlers/storyHandler.js";
 import { detectMediaContent, handleMediaMessageWrapper } from "../handlers/mediaHandler.js";
-import { MessageContext, ZaileysClient, StoredViewOnceMessage, ChatType } from "../../types/index.js";
+import { MessageContext, ZaileysClient, StoredViewOnceMessage, ChatType, SenderDevice } from "../../types/index.js";
 
 /**
  * Processes and stores a received message - only saves view once messages
@@ -29,18 +29,37 @@ export async function storeMessage(ctx: MessageContext): Promise<void> {
 			const messageData: StoredViewOnceMessage = {
 				// Main message metadata
 				chatId: ctx.chatId,
-				...(ctx.channelId && { channelId: ctx.channelId }),
-				...(ctx.uniqueId && { uniqueId: ctx.uniqueId }),
+				channelId: ctx.channelId,
+				uniqueId: ctx.uniqueId,
 				roomId: ctx.roomId,
 				roomName: ctx.roomName,
 				senderId: ctx.senderId,
 				senderName: ctx.senderName,
-				...(ctx.senderDevice && { senderDevice: ctx.senderDevice }),
+				senderDevice: ctx.senderDevice,
 				timestamp: ctx.timestamp,
-				...(ctx.text && { text: ctx.text }),
-				...(ctx.isFromMe !== undefined && { isFromMe: ctx.isFromMe }),
+				text: ctx.text,
+				isFromMe: ctx.isFromMe,
 				isGroup: ctx.isGroup,
 				chatType: ctx.chatType,
+
+				// All required fields from BaseStoredMessage
+				receiverId: ctx.receiverId,
+				receiverName: ctx.receiverName,
+				mentions: ctx.mentions,
+				links: ctx.links,
+				isPrefix: ctx.isPrefix,
+				isSpam: ctx.isSpam,
+				isTagMe: ctx.isTagMe,
+				isStory: ctx.isStory,
+				isViewOnce: ctx.isViewOnce,
+				isEdited: ctx.isEdited,
+				isDeleted: ctx.isDeleted,
+				isPinned: ctx.isPinned,
+				isUnPinned: ctx.isUnPinned,
+				isChannel: ctx.isChannel,
+				isBroadcast: ctx.isBroadcast,
+				isEphemeral: ctx.isEphemeral,
+				isForwarded: ctx.isForwarded,
 
 				// View once media info
 				viewOnceMediaPath: repliedData.viewOnceImagePath,
@@ -49,20 +68,38 @@ export async function storeMessage(ctx: MessageContext): Promise<void> {
 				// Replied message data (the view once content)
 				viewOnceMessage: ctx.replied ? {
 					chatId: ctx.replied.chatId,
-					...(ctx.replied.channelId && { channelId: ctx.replied.channelId }),
-					...(ctx.replied.uniqueId && { uniqueId: ctx.replied.uniqueId }),
+					channelId: ctx.replied.channelId,
+					uniqueId: ctx.replied.uniqueId,
 					roomId: ctx.replied.roomId,
 					roomName: ctx.replied.roomName,
 					senderId: ctx.replied.senderId,
 					senderName: ctx.replied.senderName,
-					...(ctx.replied.senderDevice && { senderDevice: ctx.replied.senderDevice }),
+					senderDevice: ctx.replied.senderDevice,
 					timestamp: ctx.replied.timestamp,
-					...(ctx.replied.text && { text: ctx.replied.text }),
-					...(ctx.replied.isFromMe !== undefined && { isFromMe: ctx.replied.isFromMe }),
+					text: ctx.replied.text,
+					isFromMe: ctx.replied.isFromMe,
 					isGroup: ctx.replied.isGroup,
 					chatType: ctx.replied.chatType,
-					...(ctx.replied.isViewOnce !== undefined && { isViewOnce: ctx.replied.isViewOnce }),
-					
+
+					// All required fields from BaseStoredMessage
+					receiverId: ctx.replied.receiverId,
+					receiverName: ctx.replied.receiverName,
+					mentions: ctx.replied.mentions,
+					links: ctx.replied.links,
+					isPrefix: ctx.replied.isPrefix,
+					isSpam: ctx.replied.isSpam,
+					isTagMe: ctx.replied.isTagMe,
+					isStory: ctx.replied.isStory,
+					isViewOnce: ctx.replied.isViewOnce,
+					isEdited: ctx.replied.isEdited,
+					isDeleted: ctx.replied.isDeleted,
+					isPinned: ctx.replied.isPinned,
+					isUnPinned: ctx.replied.isUnPinned,
+					isChannel: ctx.replied.isChannel,
+					isBroadcast: ctx.replied.isBroadcast,
+					isEphemeral: ctx.replied.isEphemeral,
+					isForwarded: ctx.replied.isForwarded,
+
 					// Media metadata
 					media: {
 						mimetype: ctx.replied.media?.mimetype || '',
@@ -72,14 +109,37 @@ export async function storeMessage(ctx: MessageContext): Promise<void> {
 						...(ctx.replied.media?.viewOnce !== undefined && { viewOnce: ctx.replied.media.viewOnce })
 					}
 				} : {
+					// Default values for all required fields
 					chatId: '',
+					channelId: '',
+					uniqueId: '',
 					roomId: '',
 					roomName: '',
 					senderId: '',
 					senderName: '',
+					senderDevice: 'unknown' as SenderDevice,
 					timestamp: 0,
+					text: null,
+					isFromMe: false,
 					isGroup: false,
 					chatType: 'text' as ChatType,
+					receiverId: '',
+					receiverName: '',
+					mentions: [],
+					links: [],
+					isPrefix: false,
+					isSpam: false,
+					isTagMe: false,
+					isStory: false,
+					isViewOnce: false,
+					isEdited: false,
+					isDeleted: false,
+					isPinned: false,
+					isUnPinned: false,
+					isChannel: false,
+					isBroadcast: false,
+					isEphemeral: false,
+					isForwarded: false,
 					media: { mimetype: '' }
 				},
 				
@@ -89,6 +149,7 @@ export async function storeMessage(ctx: MessageContext): Promise<void> {
 					roomName: ctx.roomName,
 					senderId: ctx.senderId,
 					senderName: ctx.senderName,
+					senderDevice: ctx.senderDevice,
 					isGroup: ctx.isGroup
 				}
 			};

--- a/src/handlers/storyHandler.ts
+++ b/src/handlers/storyHandler.ts
@@ -82,26 +82,45 @@ export async function storeStory(ctx: MessageContext): Promise<void> {
 		const storyData: StoredStoryMessage = {
 			// Basic message properties
 			chatId: ctx.chatId,
-			...(ctx.channelId && { channelId: ctx.channelId }),
-			...(ctx.uniqueId && { uniqueId: ctx.uniqueId }),
+			channelId: ctx.channelId,
+			uniqueId: ctx.uniqueId,
 			roomId: ctx.roomId,
 			roomName: ctx.roomName,
 			senderId: ctx.senderId,
 			senderName: ctx.senderName,
-			...(ctx.senderDevice && { senderDevice: ctx.senderDevice }),
+			senderDevice: ctx.senderDevice,
 			timestamp: ctx.timestamp,
-			...(ctx.text && { text: ctx.text }),
-			...(ctx.isFromMe !== undefined && { isFromMe: ctx.isFromMe }),
+			text: ctx.text,
+			isFromMe: ctx.isFromMe,
 			isGroup: ctx.isGroup,
 			chatType: ctx.chatType,
-			
+
+			// All required fields from BaseStoredMessage
+			receiverId: ctx.receiverId,
+			receiverName: ctx.receiverName,
+			mentions: ctx.mentions,
+			links: ctx.links,
+			isPrefix: ctx.isPrefix,
+			isSpam: ctx.isSpam,
+			isTagMe: ctx.isTagMe,
+			isStory: ctx.isStory,
+			isViewOnce: ctx.isViewOnce,
+			isEdited: ctx.isEdited,
+			isDeleted: ctx.isDeleted,
+			isPinned: ctx.isPinned,
+			isUnPinned: ctx.isUnPinned,
+			isChannel: ctx.isChannel,
+			isBroadcast: ctx.isBroadcast,
+			isEphemeral: ctx.isEphemeral,
+			isForwarded: ctx.isForwarded,
+
 			// Processing metadata
 			processedAt: new Date().toISOString(),
-			
+
 			// Add media path if successfully saved
 			storyMediaPath,
 			mediaType: ctx.chatType,
-			
+
 			// Story specific data
 			storyData: {
 				isStory: true,

--- a/src/handlers/viewOnceHandler.ts
+++ b/src/handlers/viewOnceHandler.ts
@@ -95,7 +95,7 @@ export async function handleRepliedMessage(ctx: MessageContext): Promise<ViewOnc
 						const viewOnceData: ViewOnceData = {
 							viewOnceImagePath: viewOncePath,
 							viewOnceMediaType: mediaType,
-							originalMimetype: ctx.replied.media.mimetype,
+							originalMimetype: ctx.replied.media.mimetype || '',
 							...(ctx.replied.media.caption && { originalCaption: ctx.replied.media.caption }),
 							mediaMetadata: {
 								...(ctx.replied.media.height && { height: ctx.replied.media.height }),

--- a/src/services/messageStorage.ts
+++ b/src/services/messageStorage.ts
@@ -9,7 +9,7 @@ const ChatTypeSchema = z.enum([
 	'text',
 
 	// Media Messages
-	'image', 'video', 'audio', 'document', 'sticker', 'ptv',
+	'image', 'video', 'audio', 'voice', 'document', 'sticker', 'ptv',
 
 	// Interactive Messages
 	'contact', 'location', 'liveLocation', 'list', 'listResponse', 'buttons',
@@ -48,24 +48,24 @@ const BaseStoredMessageSchema = z.object({
 	chatType: ChatTypeSchema,
 	processedAt: z.string().optional(),
 
-	// Additional fields that may be useful for stored messages
-	receiverId: z.string().optional(),
-	receiverName: z.string().optional(),
-	mentions: z.array(z.string()).optional(),
-	links: z.array(z.string()).optional(),
-	isPrefix: z.boolean().optional(),
-	isSpam: z.boolean().optional(),
-	isTagMe: z.boolean().optional(),
-	isStory: z.boolean().optional(),
-	isViewOnce: z.boolean().optional(),
-	isEdited: z.boolean().optional(),
-	isDeleted: z.boolean().optional(),
-	isPinned: z.boolean().optional(),
-	isUnPinned: z.boolean().optional(),
-	isChannel: z.boolean().optional(),
-	isBroadcast: z.boolean().optional(),
-	isEphemeral: z.boolean().optional(),
-	isForwarded: z.boolean().optional(),
+	// Additional fields from MessageContext
+	receiverId: z.string(),
+	receiverName: z.string(),
+	mentions: z.array(z.string()),
+	links: z.array(z.string()),
+	isPrefix: z.boolean(),
+	isSpam: z.boolean(),
+	isTagMe: z.boolean(),
+	isStory: z.boolean(),
+	isViewOnce: z.boolean(),
+	isEdited: z.boolean(),
+	isDeleted: z.boolean(),
+	isPinned: z.boolean(),
+	isUnPinned: z.boolean(),
+	isChannel: z.boolean(),
+	isBroadcast: z.boolean(),
+	isEphemeral: z.boolean(),
+	isForwarded: z.boolean(),
 });
 
 const MediaInfoSchema = z.object({
@@ -76,6 +76,12 @@ const MediaInfoSchema = z.object({
 	width: z.number().optional(), // for images/videos
 	height: z.number().optional(), // for images/videos
 	caption: z.string().optional(),
+
+	// Additional properties available in the schema
+	duration: z.number().optional(), // alias for seconds
+	pages: z.number().optional(), // for documents
+	fileName: z.string().optional(), // for documents
+	viewOnce: z.boolean().optional(), // for view-once detection
 }).passthrough(); // Allow additional properties like buffer() and stream() methods
 
 const StoredMessageSchema = BaseStoredMessageSchema.extend({
@@ -93,8 +99,8 @@ const StoredMessageSchema = BaseStoredMessageSchema.extend({
 		timestamp: z.number(),
 		chatType: ChatTypeSchema,
 		text: z.string().nullable(),
-		receiverId: z.string().optional(),
-		receiverName: z.string().optional(),
+		receiverId: z.string(),
+		receiverName: z.string(),
 	}),
 	viewOnceData: z.object({
 		viewOnceImagePath: z.string(),

--- a/src/services/messageStorage.ts
+++ b/src/services/messageStorage.ts
@@ -3,53 +3,98 @@ import { z } from "zod";
 import { botLogger } from "../../logger.js";
 import { AnyStoredMessage } from "../../types/index.js";
 
-// Zod schema for validating stored messages
+// Zod schema for validating stored messages - updated to match complete ChatType enum
 const ChatTypeSchema = z.enum([
-	'text', 'image', 'video', 'audio', 'voice', 'document', 'sticker',
-	'location', 'contact', 'viewOnce', 'story'
+	// Text Messages
+	'text',
+
+	// Media Messages
+	'image', 'video', 'audio', 'document', 'sticker', 'ptv',
+
+	// Interactive Messages
+	'contact', 'location', 'liveLocation', 'list', 'listResponse', 'buttons',
+	'buttonsResponse', 'interactive', 'interactiveResponse', 'template', 'templateButtonReply',
+
+	// Poll Messages
+	'pollCreation', 'pollUpdate',
+
+	// Special Messages
+	'reaction', 'viewOnce', 'ephemeral', 'protocol', 'groupInvite', 'product',
+	'order', 'invoice', 'event', 'comment', 'callLog',
+
+	// System Messages
+	'deviceSent', 'contactsArray', 'highlyStructured', 'sendPayment', 'requestPayment',
+	'declinePaymentRequest', 'cancelPaymentRequest', 'paymentInvite', 'keepInChat',
+	'requestPhoneNumber', 'groupMentioned', 'pinInChat', 'scheduledCallCreation',
+	'scheduledCallEdit', 'botInvoke', 'encComment', 'bcall', 'lottieSticker',
+	'placeholder', 'encEventUpdate'
 ]);
+
+const SenderDeviceSchema = z.enum(['unknown', 'android', 'ios', 'desktop', 'web']);
 
 const BaseStoredMessageSchema = z.object({
 	chatId: z.string(),
-	channelId: z.string().optional(),
-	uniqueId: z.string().optional(),
+	channelId: z.string(),
+	uniqueId: z.string(),
 	roomId: z.string(),
 	roomName: z.string(),
 	senderId: z.string(),
 	senderName: z.string(),
-	senderDevice: z.string().optional(),
+	senderDevice: SenderDeviceSchema,
 	timestamp: z.union([z.number(), z.string()]),
-	text: z.string().optional(),
-	isFromMe: z.boolean().optional(),
+	text: z.string().nullable(),
+	isFromMe: z.boolean(),
 	isGroup: z.boolean(),
 	chatType: ChatTypeSchema,
 	processedAt: z.string().optional(),
+
+	// Additional fields that may be useful for stored messages
+	receiverId: z.string().optional(),
+	receiverName: z.string().optional(),
+	mentions: z.array(z.string()).optional(),
+	links: z.array(z.string()).optional(),
+	isPrefix: z.boolean().optional(),
+	isSpam: z.boolean().optional(),
+	isTagMe: z.boolean().optional(),
+	isStory: z.boolean().optional(),
+	isViewOnce: z.boolean().optional(),
+	isEdited: z.boolean().optional(),
+	isDeleted: z.boolean().optional(),
+	isPinned: z.boolean().optional(),
+	isUnPinned: z.boolean().optional(),
+	isChannel: z.boolean().optional(),
+	isBroadcast: z.boolean().optional(),
+	isEphemeral: z.boolean().optional(),
+	isForwarded: z.boolean().optional(),
 });
 
 const MediaInfoSchema = z.object({
-	mimetype: z.string(),
-	caption: z.string().optional(),
-	height: z.number().optional(),
-	width: z.number().optional(),
+	mimetype: z.string().optional(),
+	fileSha256: z.instanceof(Buffer).optional(),
 	fileLength: z.number().optional(),
-	duration: z.number().optional(),
-	pages: z.number().optional(),
-	fileName: z.string().optional(),
-	viewOnce: z.boolean().optional(),
-}).passthrough(); // Allow additional properties like buffer() and stream()
+	seconds: z.number().optional(), // for audio/video
+	width: z.number().optional(), // for images/videos
+	height: z.number().optional(), // for images/videos
+	caption: z.string().optional(),
+}).passthrough(); // Allow additional properties like buffer() and stream() methods
 
 const StoredMessageSchema = BaseStoredMessageSchema.extend({
 	id: z.string(),
 	originalMessage: z.object({
 		chatId: z.string(),
+		channelId: z.string(),
+		uniqueId: z.string(),
 		roomId: z.string(),
 		roomName: z.string(),
 		senderId: z.string(),
 		senderName: z.string(),
+		senderDevice: SenderDeviceSchema,
 		isGroup: z.boolean(),
 		timestamp: z.number(),
 		chatType: ChatTypeSchema,
-		text: z.string().optional(),
+		text: z.string().nullable(),
+		receiverId: z.string().optional(),
+		receiverName: z.string().optional(),
 	}),
 	viewOnceData: z.object({
 		viewOnceImagePath: z.string(),
@@ -70,6 +115,7 @@ const StoredMessageSchema = BaseStoredMessageSchema.extend({
 		roomName: z.string(),
 		senderId: z.string(),
 		senderName: z.string(),
+		senderDevice: SenderDeviceSchema,
 		isGroup: z.boolean(),
 	}),
 });
@@ -85,6 +131,7 @@ const StoredMediaMessageSchema = BaseStoredMessageSchema.extend({
 		roomName: z.string(),
 		isGroup: z.boolean(),
 		senderName: z.string(),
+		senderDevice: SenderDeviceSchema,
 	}),
 });
 
@@ -99,6 +146,7 @@ const StoredViewOnceMessageSchema = BaseStoredMessageSchema.extend({
 		roomName: z.string(),
 		senderId: z.string(),
 		senderName: z.string(),
+		senderDevice: SenderDeviceSchema,
 		isGroup: z.boolean(),
 	}),
 });

--- a/types/index.ts
+++ b/types/index.ts
@@ -37,6 +37,7 @@ export type ChatType =
   | 'image'
   | 'video'
   | 'audio'
+  | 'voice' // voice messages
   | 'document'
   | 'sticker'
   | 'ptv'
@@ -114,15 +115,21 @@ export interface MediaInfo {
   width?: number; // for images/videos
   height?: number; // for images/videos
   caption?: string;
-  // ... other media-specific properties can be added as needed
 
-  // Methods to access media content
-  buffer(): Promise<Buffer>;
-  stream(): Promise<Readable>;
+  // Additional properties available in the schema
+  duration?: number; // alias for seconds
+  pages?: number; // for documents
+  fileName?: string; // for documents
+  viewOnce?: boolean; // for view-once detection
+
+  // Methods to access media content (optional for stored messages)
+  buffer?(): Promise<Buffer>;
+  stream?(): Promise<Readable>;
 }
 
 /**
  * Complete MessageContext interface matching Zaileys library schema
+ * This matches the actual ctx object that Zaileys provides
  */
 export interface MessageContext {
   // Core Identifiers
@@ -196,7 +203,7 @@ export type ConnectionStatus =
 // ============================================================================
 
 /**
- * Base interface for stored messages, updated to match new MessageContext schema
+ * Base interface for stored messages, matching the actual MessageContext schema
  */
 export interface BaseStoredMessage {
   chatId: string;
@@ -214,24 +221,24 @@ export interface BaseStoredMessage {
   chatType: ChatType;
   processedAt?: string;
 
-  // Additional fields that may be useful for stored messages
-  receiverId?: string;
-  receiverName?: string;
-  mentions?: string[];
-  links?: string[];
-  isPrefix?: boolean;
-  isSpam?: boolean;
-  isTagMe?: boolean;
-  isStory?: boolean;
-  isViewOnce?: boolean;
-  isEdited?: boolean;
-  isDeleted?: boolean;
-  isPinned?: boolean;
-  isUnPinned?: boolean;
-  isChannel?: boolean;
-  isBroadcast?: boolean;
-  isEphemeral?: boolean;
-  isForwarded?: boolean;
+  // Additional fields from MessageContext that may be useful for stored messages
+  receiverId: string;
+  receiverName: string;
+  mentions: string[];
+  links: string[];
+  isPrefix: boolean;
+  isSpam: boolean;
+  isTagMe: boolean;
+  isStory: boolean;
+  isViewOnce: boolean;
+  isEdited: boolean;
+  isDeleted: boolean;
+  isPinned: boolean;
+  isUnPinned: boolean;
+  isChannel: boolean;
+  isBroadcast: boolean;
+  isEphemeral: boolean;
+  isForwarded: boolean;
 }
 
 export interface StoredMessage extends BaseStoredMessage {
@@ -536,7 +543,7 @@ export type AnyStoredMessage = StoredMessage | StoredMediaMessage | StoredViewOn
 // UTILITY TYPES
 // ============================================================================
 
-export type SupportedMediaType = Extract<ChatType, 'image' | 'video' | 'document' | 'audio' | 'sticker' | 'ptv'>;
+export type SupportedMediaType = Extract<ChatType, 'image' | 'video' | 'document' | 'audio' | 'voice' | 'sticker' | 'ptv'>;
 
 export interface FileExtensionMap {
   [key: string]: string;

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,9 +1,11 @@
 /**
  * TypeScript type definitions for Stealth Companion WhatsApp Bot
  * Comprehensive type definitions for all interfaces and data structures
+ * Updated to match the accurate Zaileys library context schema
  */
 
 import winston from 'winston';
+import { Readable } from 'stream';
 
 // ============================================================================
 // ZAILEYS CLIENT TYPES
@@ -16,57 +18,159 @@ export interface ZaileysClient {
 }
 
 // ============================================================================
+// ENUMS
+// ============================================================================
+
+/**
+ * Device type of the message sender
+ */
+export type SenderDevice = "unknown" | "android" | "ios" | "desktop" | "web";
+
+/**
+ * Complete ChatType enum matching Zaileys library schema
+ */
+export type ChatType =
+  // Text Messages
+  | 'text'
+
+  // Media Messages
+  | 'image'
+  | 'video'
+  | 'audio'
+  | 'document'
+  | 'sticker'
+  | 'ptv'
+
+  // Interactive Messages
+  | 'contact'
+  | 'location'
+  | 'liveLocation'
+  | 'list'
+  | 'listResponse'
+  | 'buttons'
+  | 'buttonsResponse'
+  | 'interactive'
+  | 'interactiveResponse'
+  | 'template'
+  | 'templateButtonReply'
+
+  // Poll Messages
+  | 'pollCreation'
+  | 'pollUpdate'
+
+  // Special Messages
+  | 'reaction'
+  | 'viewOnce'
+  | 'ephemeral'
+  | 'protocol'
+  | 'groupInvite'
+  | 'product'
+  | 'order'
+  | 'invoice'
+  | 'event'
+  | 'comment'
+  | 'callLog'
+
+  // System Messages
+  | 'deviceSent'
+  | 'contactsArray'
+  | 'highlyStructured'
+  | 'sendPayment'
+  | 'requestPayment'
+  | 'declinePaymentRequest'
+  | 'cancelPaymentRequest'
+  | 'paymentInvite'
+  | 'keepInChat'
+  | 'requestPhoneNumber'
+  | 'groupMentioned'
+  | 'pinInChat'
+  | 'scheduledCallCreation'
+  | 'scheduledCallEdit'
+  | 'botInvoke'
+  | 'encComment'
+  | 'bcall'
+  | 'lottieSticker'
+  | 'placeholder'
+  | 'encEventUpdate';
+
+// ============================================================================
 // MESSAGE CONTEXT TYPES
 // ============================================================================
 
+/**
+ * Citation object containing dynamic boolean flags based on client configuration
+ */
+export type Citation = Record<string, boolean> | null;
+
+/**
+ * Enhanced MediaInfo interface matching Zaileys library schema
+ */
 export interface MediaInfo {
-  mimetype: string;
-  caption?: string;
-  height?: number;
-  width?: number;
+  // Media metadata (varies by type)
+  mimetype?: string;
+  fileSha256?: Buffer;
   fileLength?: number;
-  duration?: number; // For audio/video
-  pages?: number; // For documents
-  fileName?: string; // For documents
-  viewOnce?: boolean;
-  buffer?(): Promise<Buffer>; // For downloading media as buffer
-  stream?(): Promise<NodeJS.ReadableStream>; // For downloading media as stream
+  seconds?: number; // for audio/video
+  width?: number; // for images/videos
+  height?: number; // for images/videos
+  caption?: string;
+  // ... other media-specific properties can be added as needed
+
+  // Methods to access media content
+  buffer(): Promise<Buffer>;
+  stream(): Promise<Readable>;
 }
 
+/**
+ * Complete MessageContext interface matching Zaileys library schema
+ */
 export interface MessageContext {
+  // Core Identifiers
   chatId: string;
-  channelId?: string;
-  uniqueId?: string;
+  channelId: string;
+  uniqueId: string;
+
+  // Participant Information
+  receiverId: string;
+  receiverName: string;
   roomId: string;
   roomName: string;
   senderId: string;
   senderName: string;
-  senderDevice?: string;
+  senderDevice: SenderDevice;
+
+  // Message Content
+  chatType: ChatType;
+  timestamp: number;
+  text: string | null;
+  mentions: string[];
+  links: string[];
+
+  // Boolean Flags
+  isPrefix: boolean;
+  isSpam: boolean;
+  isFromMe: boolean;
+  isTagMe: boolean;
   isGroup: boolean;
   isStory: boolean;
+  isViewOnce: boolean;
   isEdited: boolean;
   isDeleted: boolean;
-  isViewOnce?: boolean;
-  isFromMe?: boolean;
-  chatType: ChatType;
-  text?: string;
-  timestamp: number;
-  media?: MediaInfo;
-  replied?: MessageContext;
-}
+  isPinned: boolean;
+  isUnPinned: boolean;
+  isChannel: boolean;
+  isBroadcast: boolean;
+  isEphemeral: boolean;
+  isForwarded: boolean;
 
-export type ChatType = 
-  | 'text' 
-  | 'image' 
-  | 'video' 
-  | 'audio' 
-  | 'voice' 
-  | 'document' 
-  | 'sticker' 
-  | 'location' 
-  | 'contact' 
-  | 'viewOnce'
-  | 'story';
+  // Special Objects
+  citation: Citation;
+  media: MediaInfo | null;
+  replied: MessageContext | null;
+
+  // Message Function
+  message(): any; // proto.IWebMessageInfo - will be properly typed when Baileys types are imported
+}
 
 // ============================================================================
 // CONNECTION CONTEXT TYPES
@@ -91,35 +195,62 @@ export type ConnectionStatus =
 // STORED MESSAGE TYPES
 // ============================================================================
 
+/**
+ * Base interface for stored messages, updated to match new MessageContext schema
+ */
 export interface BaseStoredMessage {
   chatId: string;
-  channelId?: string;
-  uniqueId?: string;
+  channelId: string;
+  uniqueId: string;
   roomId: string;
   roomName: string;
   senderId: string;
   senderName: string;
-  senderDevice?: string;
+  senderDevice: SenderDevice;
   timestamp: number | string;
-  text?: string;
-  isFromMe?: boolean;
+  text: string | null;
+  isFromMe: boolean;
   isGroup: boolean;
   chatType: ChatType;
   processedAt?: string;
+
+  // Additional fields that may be useful for stored messages
+  receiverId?: string;
+  receiverName?: string;
+  mentions?: string[];
+  links?: string[];
+  isPrefix?: boolean;
+  isSpam?: boolean;
+  isTagMe?: boolean;
+  isStory?: boolean;
+  isViewOnce?: boolean;
+  isEdited?: boolean;
+  isDeleted?: boolean;
+  isPinned?: boolean;
+  isUnPinned?: boolean;
+  isChannel?: boolean;
+  isBroadcast?: boolean;
+  isEphemeral?: boolean;
+  isForwarded?: boolean;
 }
 
 export interface StoredMessage extends BaseStoredMessage {
   id: string;
   originalMessage: {
     chatId: string;
+    channelId: string;
+    uniqueId: string;
     roomId: string;
     roomName: string;
     senderId: string;
     senderName: string;
+    senderDevice: SenderDevice;
     isGroup: boolean;
     timestamp: number;
     chatType: ChatType;
-    text?: string;
+    text: string | null;
+    receiverId?: string;
+    receiverName?: string;
   };
   viewOnceData: ViewOnceData;
   replyContext: ReplyContext;
@@ -138,6 +269,7 @@ export interface ReplyContext {
   roomName: string;
   senderId: string;
   senderName: string;
+  senderDevice: SenderDevice;
   isGroup: boolean;
 }
 
@@ -145,7 +277,7 @@ export interface MediaMetadata {
   height?: number;
   width?: number;
   fileLength?: number;
-  duration?: number;
+  duration?: number; // renamed from seconds for consistency
   pages?: number;
   fileName?: string;
 }
@@ -161,14 +293,19 @@ export interface MediaMessage {
   timestamp: number;
   originalMessage: {
     chatId: string;
+    channelId: string;
+    uniqueId: string;
     roomId: string;
     roomName: string;
     senderId: string;
     senderName: string;
+    senderDevice: SenderDevice;
     isGroup: boolean;
     timestamp: number;
     chatType: ChatType;
-    text?: string;
+    text: string | null;
+    receiverId?: string;
+    receiverName?: string;
   };
   media: MediaInfo;
   processedAt: string;
@@ -182,6 +319,7 @@ export interface RoomContext {
   roomName: string;
   isGroup: boolean;
   senderName: string;
+  senderDevice: SenderDevice;
 }
 
 // ============================================================================
@@ -398,7 +536,7 @@ export type AnyStoredMessage = StoredMessage | StoredMediaMessage | StoredViewOn
 // UTILITY TYPES
 // ============================================================================
 
-export type SupportedMediaType = Extract<ChatType, 'image' | 'video' | 'document' | 'audio' | 'voice' | 'sticker'>;
+export type SupportedMediaType = Extract<ChatType, 'image' | 'video' | 'document' | 'audio' | 'sticker' | 'ptv'>;
 
 export interface FileExtensionMap {
   [key: string]: string;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new media type "ptv" (video formats) with enhanced metadata capture.
  * Expanded message context and storage to include detailed participant info, device type, and comprehensive message flags.

* **Documentation**
  * Introduced a detailed schema reference for the message context object used in event handlers.
  * Updated multiple documentation files to emphasize structural consistency and comprehensive feature support.

* **Bug Fixes**
  * Ensured all stored messages and media have complete and consistent metadata, including default values for missing fields.
  * Improved robustness by guaranteeing string values for certain media properties.

* **Chores**
  * Removed obsolete backward-compatibility code and legacy comments for cleaner maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->